### PR TITLE
Adjust taste profile card sizing

### DIFF
--- a/project/frontend/src/App.tsx
+++ b/project/frontend/src/App.tsx
@@ -836,24 +836,24 @@ export default function App() {
                           </div>
                         </div>
 
-                        <div className="grid gap-4 md:grid-cols-2">
+                        <div className="grid gap-4 md:grid-cols-2 auto-rows-fr">
                           {tasteSections.map((section, index) => (
                             <div
                               key={`${section.title}-${index}`}
-                              className={`rounded-[2rem] border bg-gradient-to-br ${section.accent} p-6 backdrop-blur-sm`}
+                              className={`flex h-full flex-col rounded-[2rem] border bg-gradient-to-br ${section.accent} p-5 md:p-6 backdrop-blur-sm`}
                             >
                               <div className="flex items-start justify-between gap-3">
                                 <div>
                                   <p className="text-[10px] font-black uppercase tracking-[0.3em] text-gray-400">Taste Cue {String(index + 1).padStart(2, '0')}</p>
-                                  <h5 className="mt-2 text-xl font-black tracking-tight text-black capitalize">{section.title}</h5>
+                                  <h5 className="mt-2 text-lg md:text-xl font-black tracking-tight text-black capitalize">{section.title}</h5>
                                 </div>
-                                <Compass className="h-5 w-5 text-gray-400" />
+                                <Compass className="h-5 w-5 shrink-0 text-gray-400" />
                               </div>
-                              <div className="mt-5 space-y-3">
+                              <div className="mt-4 grid gap-2 sm:grid-cols-2">
                                 {section.body.map((line, lineIndex) => (
-                                  <div key={`${section.title}-${lineIndex}`} className="flex gap-3 rounded-2xl bg-white/80 px-4 py-3 shadow-sm shadow-black/5">
-                                    <div className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-black" />
-                                    <p className="text-sm font-medium leading-6 text-gray-700">{line}</p>
+                                  <div key={`${section.title}-${lineIndex}`} className="flex items-start gap-3 rounded-xl bg-white/80 px-3.5 py-2.5 shadow-sm shadow-black/5">
+                                    <div className="mt-1 h-2 w-2 shrink-0 rounded-full bg-black" />
+                                    <p className="text-sm font-medium leading-5 text-gray-700 break-words">{line}</p>
                                   </div>
                                 ))}
                               </div>


### PR DESCRIPTION
### Motivation
- The taste profile boxes were stretching vertically and looked visually unbalanced on the profile page. 
- Make the profile cards fill the grid evenly and present taste bullets in a denser, more readable layout.

### Description
- Updated the taste profile grid to `auto-rows-fr` so each card fills the row evenly and prevents excessive vertical stretching in `project/frontend/src/App.tsx`.
- Converted each taste card to a column flexbox with `flex h-full flex-col` and reduced padding to `p-5 md:p-6` so cards keep consistent heights and tighter spacing.
- Reduced the card title sizing from `text-xl` to `text-lg md:text-xl` and added `shrink-0` to the `Compass` icon to stabilize layout.
- Reworked the taste bullet list from a vertical stack to a compact two-column grid using `grid gap-2 sm:grid-cols-2` and tightened bullet paddings and line-height for denser display.

### Testing
- Ran `npm run build` (Vite) which completed successfully and produced the optimized `dist` output (build succeeded, with a warning about chunk size over 500 kB).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfea3cbb94832aa270a69821b5870c)