### PR TITLE
refactor(db): extract repository layer and recover stale serverless connections

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import os
-import json
 import uuid
 import html
 import asyncio
@@ -12,12 +11,10 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, APIRouter,
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 from dotenv import load_dotenv
 from time import time
 from psycopg_pool import AsyncConnectionPool
-from psycopg.rows import dict_row  
 from playwright.async_api import async_playwright
 from project.backend.Step1.Rapid_api_crawler import Rapid_crawler
 from project.backend.Step1.shopping_crawler import scrape_product_metadata
@@ -26,50 +23,25 @@ from project.backend.Step2.image_ocr_llm import extract_fact_and_vibe
 from project.backend.Step2.insert_DB import insert_items_to_db 
 from project.backend.Step2.preferance_llm import analyze_vibe      
 from project.backend.Step1.utils import analyze_description_with_gemini
+from project.backend.db import (
+    create_db_pool,
+    create_manual_item,
+    create_processing_item,
+    delete_saved_post_by_id,
+    fetch_items,
+    fetch_taste_profile,
+    get_db_connection as get_pooled_db_connection,
+    get_latest_taste_summary,
+    init_db,
+    upsert_taste_profile,
+    count_saved_posts,
+)
 
 load_dotenv()
 NEON_DB_URL = os.environ.get("NEON_DB_URL")
 SERP_API_KEY = os.environ.get("SERP_API_KEY")
 
-# ==========================================
-# 1. 전역 DB 커넥션 풀 관리 & 초기화
-# ==========================================
 pool: AsyncConnectionPool = None
-
-async def init_db(db_pool: AsyncConnectionPool):
-    """비동기 방식으로 DB 테이블 스키마를 초기화"""
-    try:
-        async with db_pool.connection() as conn:
-            async with conn.cursor() as cursor:
-                await cursor.execute("""
-                  CREATE TABLE IF NOT EXISTS saved_posts (
-                    id SERIAL PRIMARY KEY,
-                    user_id TEXT,
-                    source_url TEXT,
-                    title TEXT,
-                    category TEXT,
-                    summary_text TEXT,
-                    image_url TEXT,
-                    vibe_text TEXT,
-                    vibe_vector vector(768),
-                    facts JSONB,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    UNIQUE(source_url, title)
-                  );
-                """)
-
-                await cursor.execute("""
-                  CREATE TABLE IF NOT EXISTS taste_profile (
-                    id INTEGER PRIMARY KEY DEFAULT 1,
-                    summary TEXT,
-                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    CONSTRAINT one_row CHECK (id = 1)
-                  );
-                """)
-                await conn.commit()
-        print("DB 테이블 초기화 완료")
-    except Exception as e:
-        print(f"DB 초기화 중 경고: {e}")
 
 # FastAPI 라이프사이클
 @asynccontextmanager
@@ -79,7 +51,7 @@ async def lifespan(app: FastAPI):
         raise RuntimeError("NEON_DB_URL environment variable is not set.")
     
     # 트래픽에 맞춰 최소 5개 ~ 최대 20개의 연결을 유지하는 풀 생성
-    pool = AsyncConnectionPool(conninfo=NEON_DB_URL, min_size=5, max_size=20)
+    pool = create_db_pool(conninfo=NEON_DB_URL, min_size=5, max_size=20)
     print("DB 커넥션 풀 생성 완료")
     
     # 풀이 생성되면 테이블 스키마 확인
@@ -109,13 +81,8 @@ app.add_middleware(
 
 # 의존성(Dependency) 주입 함수
 async def get_db_connection():
-    if pool is None:
-        raise HTTPException(status_code=500, detail="Database pool is not initialized")
-    conn = await pool.getconn()
-    try:
+    async for conn in get_pooled_db_connection(pool):
         yield conn
-    finally:
-        await pool.putconn(conn)
 
 # ==========================================
 # 3. Pydantic Models 
@@ -248,17 +215,15 @@ async def background_crawl_and_save(item_id: int, user_id: str, post_url: str, s
 
         try:
             async with pool.connection() as conn:
-                async with conn.cursor() as cursor:
-                    # 처리 중인 임시 데이터 삭제
-                    await cursor.execute("DELETE FROM saved_posts WHERE id = %s", (item_id,))
-                    
-                    # 빌려온 conn을 그대로 전달하여 내부에서 재사용
-                    user_id = "1"
-                    await insert_items_to_db(user_id, post_url, extracted_items, conn=conn)
-                    
-                    # 최종 커밋
-                    await conn.commit()
-                    print(f"[백그라운드] 작업 및 DB 저장 완료")
+                await delete_saved_post_by_id(conn, item_id)
+
+                # 빌려온 conn을 그대로 전달하여 내부에서 재사용
+                user_id = "1"
+                await insert_items_to_db(user_id, post_url, extracted_items, conn=conn)
+
+                # 최종 커밋
+                await conn.commit()
+                print(f"[백그라운드] 작업 및 DB 저장 완료")
 
         except Exception as e:
             print(f"[백그라운드] 에러: {str(e)}")
@@ -284,14 +249,7 @@ async def extract_and_save_url(request: UrlAnalyzeRequest, background_tasks: Bac
 
     # 1. DB에 '처리 중(PROCESSING)' 상태의 빈 껍데기 선 저장
     try:
-        async with conn.cursor() as cursor:
-            await cursor.execute("""
-                INSERT INTO saved_posts (user_id, source_url, category, title, vibe_text, image_url, facts) 
-                VALUES (%s, %s, 'PROCESSING ', '분석 중...', 'AI가 열심히 바이브를 추출하고 있어요', '', '{}') 
-                RETURNING id
-            """, (user_id, post_url))
-            new_item_id = (await cursor.fetchone())[0]
-            await conn.commit()
+        new_item_id = await create_processing_item(conn, user_id, post_url)
     except Exception as e:
         await conn.rollback()
         raise HTTPException(status_code=500, detail=f"임시 데이터 저장 실패: {str(e)}")
@@ -318,62 +276,43 @@ async def extract_and_save_url(request: UrlAnalyzeRequest, background_tasks: Bac
 @app.post("/api/generate-taste")
 async def generate_taste_profile(conn = Depends(get_db_connection)):
     try:
-        async with conn.cursor(row_factory=dict_row) as cursor:
-            # 1. 아이템 존재 여부 체크
-            await cursor.execute("SELECT COUNT(*) AS count FROM saved_posts WHERE user_id = '1'")
-            row = await cursor.fetchone()
-            count = row['count'] if row else 0
+        # 1. 아이템 존재 여부 체크
+        count = await count_saved_posts(conn, "1")
+        if count == 0:
+            return {"success": False, "message": "피드에 아이템이 없습니다. 먼저 아이템을 추가해 주세요."}
 
-            if count == 0:
-                return {"success": False, "message": "피드에 아이템이 없습니다. 먼저 아이템을 추가해 주세요."}
-            
-            await cursor.execute(""" SELECT summary FROM taste_profile WHERE id = 1 ORDER BY updated_at DESC LIMIT 1""")
-            existing_row = await cursor.fetchone()
-            
-            current_profile = {"persona": "정보 없음", "unconscious_taste": "데이터 부족", "recommendation": "데이터 부족"}
-            
-            if existing_row and existing_row['summary']:
-                raw_summary = existing_row['summary']
-                try:
-                    parts = raw_summary.split("\n\n")
-                    current_profile['persona'] = parts[0].replace("**페르소나**\n", "")
-                    current_profile['unconscious_taste'] = parts[1].replace("**나도 몰랐던 나의 취향**\n", "")
-                    current_profile['recommendation'] = parts[2].replace("**추천**\n", "")
-                except:
-                    pass 
-            
-            # 분석 실행 
-            summary_dict = await analyze_vibe(user_id=1, current_profile=current_profile)  
-            
-            if not summary_dict:
-                return {"success": False, "message": "취향 분석에 실패했습니다."}
-    
-            final_summary_text = (
-                f"**페르소나**\n{summary_dict.get('persona', '분석 불가')}\n\n"
-                f"**나도 몰랐던 나의 취향**\n{summary_dict.get('unconscious_taste', '내용 없음')}\n\n"
-                f"**추천**\n{summary_dict.get('recommendation', '추천 없음')}"
-            )
-            
-            # 4. DB 저장 실행
-            sql = """
-                INSERT INTO taste_profile (id, summary, updated_at) 
-                VALUES (1, %s, CURRENT_TIMESTAMP) 
-                ON CONFLICT (id) 
-                DO UPDATE SET 
-                    summary = EXCLUDED.summary,
-                    updated_at = CURRENT_TIMESTAMP
-            """
-            
+        existing_summary = await get_latest_taste_summary(conn)
+        current_profile = {"persona": "정보 없음", "unconscious_taste": "데이터 부족", "recommendation": "데이터 부족"}
+
+        if existing_summary:
             try:
-                # 조립된 마크다운 문자열(final_summary_text)을 전달
-                await cursor.execute(sql, (final_summary_text,)) 
-                await conn.commit() 
-                print(f"DB 저장 성공: {final_summary_text[:30]}...")
-            except Exception as db_e:
-                await conn.rollback()
-                print(f"DB 실행 중 에러 발생: {db_e}")
-                raise db_e
-            
+                parts = existing_summary.split("\n\n")
+                current_profile["persona"] = parts[0].replace("**페르소나**\n", "")
+                current_profile["unconscious_taste"] = parts[1].replace("**나도 몰랐던 나의 취향**\n", "")
+                current_profile["recommendation"] = parts[2].replace("**추천**\n", "")
+            except Exception:
+                pass
+
+        # 분석 실행
+        summary_dict = await analyze_vibe(user_id=1, current_profile=current_profile)
+
+        if not summary_dict:
+            return {"success": False, "message": "취향 분석에 실패했습니다."}
+
+        final_summary_text = (
+            f"**페르소나**\n{summary_dict.get('persona', '분석 불가')}\n\n"
+            f"**나도 몰랐던 나의 취향**\n{summary_dict.get('unconscious_taste', '내용 없음')}\n\n"
+            f"**추천**\n{summary_dict.get('recommendation', '추천 없음')}"
+        )
+
+        try:
+            await upsert_taste_profile(conn, final_summary_text)
+            print(f"DB 저장 성공: {final_summary_text[:30]}...")
+        except Exception as db_e:
+            await conn.rollback()
+            print(f"DB 실행 중 에러 발생: {db_e}")
+            raise db_e
+
         # 5. 프론트엔드 응답 (조립된 텍스트 전달)
         return {"success": True, "summary": final_summary_text}
 
@@ -482,23 +421,15 @@ async def run_serpapi_search(request: SearchRequest):
 @app.post("/api/items/manual")
 async def save_manual_item(request: ManualItemCreate, conn = Depends(get_db_connection)):
     try:
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                """INSERT INTO saved_posts (user_id, source_url, category, vibe_text, facts, title, image_url) 
-                   VALUES (%s, %s, %s, %s, %s, %s, %s)""",
-                (
-                    str(request.user_id), 
-                    request.url, 
-                    request.category, 
-                    request.vibe, 
-                    json.dumps(request.facts),               
-                    request.facts.get("title", "Manual Item"),
-                    request.image_url or ""
-                )
-            )
-            await conn.commit()
-
-        # 수정 2: 응답 메시지 업데이트
+        await create_manual_item(
+            conn,
+            user_id=str(request.user_id),
+            url=request.url,
+            category=request.category,
+            vibe=request.vibe,
+            facts=request.facts,
+            image_url=request.image_url or "",
+        )
         return {"success": True, "message": "웹 검색 결과가 내 피드로 이동되었습니다."}
     except Exception as e:
         await conn.rollback()
@@ -510,26 +441,9 @@ async def save_manual_item(request: ManualItemCreate, conn = Depends(get_db_conn
 @app.get("/api/items")
 async def get_items(user_id: str = "1", conn = Depends(get_db_connection)):
     try:
-        async with conn.cursor(row_factory=dict_row) as cursor:
-            query = """
-                SELECT 
-                    id, 
-                    source_url as url, 
-                    category, 
-                    facts, 
-                    vibe_text as vibe, 
-                    image_url, 
-                    summary_text, 
-                    created_at 
-                FROM saved_posts 
-                WHERE user_id = %s OR user_id = 'default_user'
-                ORDER BY created_at DESC
-            """
-            await cursor.execute(query, (user_id,))
-            items = await cursor.fetchall()
-            
+        items = await fetch_items(conn, user_id)
         print(f"프론트로 보내는 아이템 수: {len(items)}")
-        return jsonable_encoder(items)
+        return items
     except Exception as e:
         print(f"조회 에러: {e}")
         return []
@@ -537,9 +451,8 @@ async def get_items(user_id: str = "1", conn = Depends(get_db_connection)):
 @app.delete("/api/items/{item_id}")
 async def delete_item(item_id: int, conn = Depends(get_db_connection)):
     try:
-        async with conn.cursor() as cursor:
-            await cursor.execute("DELETE FROM saved_posts WHERE id = %s", (item_id,))
-            await conn.commit()
+        await delete_saved_post_by_id(conn, item_id)
+        await conn.commit()
         return {"success": True}
     except Exception as e:
         await conn.rollback()
@@ -548,10 +461,7 @@ async def delete_item(item_id: int, conn = Depends(get_db_connection)):
 @app.get("/api/taste")
 async def get_taste(conn = Depends(get_db_connection)):
     try:
-        async with conn.cursor(row_factory=dict_row) as cursor:
-            await cursor.execute("SELECT * FROM taste_profile WHERE id = 1")
-            row = await cursor.fetchone()
-        return row if row else {"summary": ""}
+        return await fetch_taste_profile(conn)
     except Exception as e:
         print(f"취향 프로필 조회 에러: {e}")
         return {"summary": ""}

--- a/main.py
+++ b/main.py
@@ -37,6 +37,25 @@ SERP_API_KEY = os.environ.get("SERP_API_KEY")
 
 pool: AsyncConnectionPool = None
 
+
+async def rebuild_db_pool() -> AsyncConnectionPool:
+    global pool
+
+    if not NEON_DB_URL:
+        raise RuntimeError("NEON_DB_URL environment variable is not set.")
+
+    old_pool = pool
+    pool = create_db_pool(conninfo=NEON_DB_URL, min_size=5, max_size=20)
+
+    if old_pool is not None and not old_pool.closed:
+        try:
+            await old_pool.close()
+        except Exception as e:
+            print(f"기존 DB 풀 종료 중 경고: {e}")
+
+    print("DB 커넥션 풀 재생성 완료")
+    return pool
+
 # FastAPI 라이프사이클
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -45,7 +64,7 @@ async def lifespan(app: FastAPI):
         raise RuntimeError("NEON_DB_URL environment variable is not set.")
     
     # 트래픽에 맞춰 최소 5개 ~ 최대 20개의 연결을 유지하는 풀 생성
-    pool = create_db_pool(conninfo=NEON_DB_URL, min_size=5, max_size=20)
+    pool = await rebuild_db_pool()
     print("DB 커넥션 풀 생성 완료")
     
     # 풀이 생성되면 테이블 스키마 확인
@@ -75,7 +94,7 @@ app.add_middleware(
 
 # 의존성(Dependency) 주입 함수
 async def get_db_connection():
-    async for conn in get_pooled_db_connection(pool):
+    async for conn in get_pooled_db_connection(pool, recreate_pool=rebuild_db_pool):
         yield conn
 
 

--- a/main.py
+++ b/main.py
@@ -24,17 +24,11 @@ from project.backend.Step2.insert_DB import insert_items_to_db
 from project.backend.Step2.preferance_llm import analyze_vibe      
 from project.backend.Step1.utils import analyze_description_with_gemini
 from project.backend.db import (
+    Repositories,
     create_db_pool,
-    create_manual_item,
-    create_processing_item,
-    delete_saved_post_by_id,
-    fetch_items,
-    fetch_taste_profile,
     get_db_connection as get_pooled_db_connection,
-    get_latest_taste_summary,
+    get_repositories,
     init_db,
-    upsert_taste_profile,
-    count_saved_posts,
 )
 
 load_dotenv()
@@ -83,6 +77,10 @@ app.add_middleware(
 async def get_db_connection():
     async for conn in get_pooled_db_connection(pool):
         yield conn
+
+
+async def get_repos(conn=Depends(get_db_connection)) -> Repositories:
+    return get_repositories(conn)
 
 # ==========================================
 # 3. Pydantic Models 
@@ -215,7 +213,8 @@ async def background_crawl_and_save(item_id: int, user_id: str, post_url: str, s
 
         try:
             async with pool.connection() as conn:
-                await delete_saved_post_by_id(conn, item_id)
+                repos = get_repositories(conn)
+                await repos.saved_posts.delete_by_id(item_id)
 
                 # 빌려온 conn을 그대로 전달하여 내부에서 재사용
                 user_id = "1"
@@ -238,7 +237,11 @@ async def background_crawl_and_save(item_id: int, user_id: str, post_url: str, s
 
 # [API 1] 크롤링 & 데이터 추출 (즉시 응답)
 @app.post("/api/extract-url")
-async def extract_and_save_url(request: UrlAnalyzeRequest, background_tasks: BackgroundTasks, conn = Depends(get_db_connection)):
+async def extract_and_save_url(
+    request: UrlAnalyzeRequest,
+    background_tasks: BackgroundTasks,
+    repos: Repositories = Depends(get_repos),
+):
     post_url = request.url
     session_id = request.session_id
     rapid_api_key = os.environ.get("RAPIDAPI_KEY")
@@ -249,9 +252,9 @@ async def extract_and_save_url(request: UrlAnalyzeRequest, background_tasks: Bac
 
     # 1. DB에 '처리 중(PROCESSING)' 상태의 빈 껍데기 선 저장
     try:
-        new_item_id = await create_processing_item(conn, user_id, post_url)
+        new_item_id = await repos.saved_posts.create_processing_item(user_id, post_url)
     except Exception as e:
-        await conn.rollback()
+        await repos.saved_posts.conn.rollback()
         raise HTTPException(status_code=500, detail=f"임시 데이터 저장 실패: {str(e)}")
 
     # 2. 백그라운드 큐에 할당 
@@ -274,14 +277,14 @@ async def extract_and_save_url(request: UrlAnalyzeRequest, background_tasks: Bac
 
 # [API 2] 취향 프로필 생성
 @app.post("/api/generate-taste")
-async def generate_taste_profile(conn = Depends(get_db_connection)):
+async def generate_taste_profile(repos: Repositories = Depends(get_repos)):
     try:
         # 1. 아이템 존재 여부 체크
-        count = await count_saved_posts(conn, "1")
+        count = await repos.saved_posts.count_by_user_id("1")
         if count == 0:
             return {"success": False, "message": "피드에 아이템이 없습니다. 먼저 아이템을 추가해 주세요."}
 
-        existing_summary = await get_latest_taste_summary(conn)
+        existing_summary = await repos.taste_profile.get_latest_summary()
         current_profile = {"persona": "정보 없음", "unconscious_taste": "데이터 부족", "recommendation": "데이터 부족"}
 
         if existing_summary:
@@ -306,10 +309,10 @@ async def generate_taste_profile(conn = Depends(get_db_connection)):
         )
 
         try:
-            await upsert_taste_profile(conn, final_summary_text)
+            await repos.taste_profile.upsert_summary(final_summary_text)
             print(f"DB 저장 성공: {final_summary_text[:30]}...")
         except Exception as db_e:
-            await conn.rollback()
+            await repos.taste_profile.conn.rollback()
             print(f"DB 실행 중 에러 발생: {db_e}")
             raise db_e
 
@@ -419,10 +422,9 @@ async def run_serpapi_search(request: SearchRequest):
 
 # [API 4] pse 검색결과 아이템 피드로 이동
 @app.post("/api/items/manual")
-async def save_manual_item(request: ManualItemCreate, conn = Depends(get_db_connection)):
+async def save_manual_item(request: ManualItemCreate, repos: Repositories = Depends(get_repos)):
     try:
-        await create_manual_item(
-            conn,
+        await repos.saved_posts.create_manual_item(
             user_id=str(request.user_id),
             url=request.url,
             category=request.category,
@@ -432,16 +434,16 @@ async def save_manual_item(request: ManualItemCreate, conn = Depends(get_db_conn
         )
         return {"success": True, "message": "웹 검색 결과가 내 피드로 이동되었습니다."}
     except Exception as e:
-        await conn.rollback()
+        await repos.saved_posts.conn.rollback()
         raise HTTPException(status_code=500, detail=f"수동 저장 실패: {str(e)}")
     
 # ==========================================
 # 6. 일반 CRUD 및 SPA 서빙 엔드포인트
 # ==========================================
 @app.get("/api/items")
-async def get_items(user_id: str = "1", conn = Depends(get_db_connection)):
+async def get_items(user_id: str = "1", repos: Repositories = Depends(get_repos)):
     try:
-        items = await fetch_items(conn, user_id)
+        items = await repos.saved_posts.list_feed_items(user_id)
         print(f"프론트로 보내는 아이템 수: {len(items)}")
         return items
     except Exception as e:
@@ -449,19 +451,19 @@ async def get_items(user_id: str = "1", conn = Depends(get_db_connection)):
         return []
 
 @app.delete("/api/items/{item_id}")
-async def delete_item(item_id: int, conn = Depends(get_db_connection)):
+async def delete_item(item_id: int, repos: Repositories = Depends(get_repos)):
     try:
-        await delete_saved_post_by_id(conn, item_id)
-        await conn.commit()
+        await repos.saved_posts.delete_by_id(item_id)
+        await repos.saved_posts.conn.commit()
         return {"success": True}
     except Exception as e:
-        await conn.rollback()
+        await repos.saved_posts.conn.rollback()
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/api/taste")
-async def get_taste(conn = Depends(get_db_connection)):
+async def get_taste(repos: Repositories = Depends(get_repos)):
     try:
-        return await fetch_taste_profile(conn)
+        return await repos.taste_profile.get_profile()
     except Exception as e:
         print(f"취향 프로필 조회 에러: {e}")
         return {"summary": ""}

--- a/project/backend/db.py
+++ b/project/backend/db.py
@@ -1,7 +1,8 @@
 import json
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Awaitable, Callable
+from psycopg import InterfaceError, OperationalError
 
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
@@ -52,15 +53,49 @@ def create_db_pool(conninfo: str, min_size: int = 5, max_size: int = 20) -> Asyn
     return AsyncConnectionPool(conninfo=conninfo, min_size=min_size, max_size=max_size)
 
 
-async def get_db_connection(pool: AsyncConnectionPool | None) -> AsyncGenerator[Any, None]:
-    if pool is None:
-        raise HTTPException(status_code=500, detail="Database pool is not initialized")
+async def _ping_connection(conn: Any) -> None:
+    # Serverless DB는 idle 이후 기존 connection이 stale 상태가 될 수 있어서,
+    # 풀에서 꺼낸 직후 가벼운 ping으로 실제 연결 가능 여부를 확인한다.
+    async with conn.cursor() as cursor:
+        await cursor.execute("SELECT 1")
+        await cursor.fetchone()
 
-    conn = await pool.getconn()
-    try:
-        yield conn
-    finally:
-        await pool.putconn(conn)
+
+async def get_db_connection(
+    pool: AsyncConnectionPool | None,
+    recreate_pool: Callable[[], Awaitable[AsyncConnectionPool]] | None = None,
+) -> AsyncGenerator[Any, None]:
+    current_pool = pool
+
+    for attempt in range(2):
+        if current_pool is None or current_pool.closed:
+            if recreate_pool is None:
+                raise HTTPException(status_code=500, detail="Database pool is not initialized")
+            current_pool = await recreate_pool()
+
+        conn = None
+        pool_used = current_pool
+        try:
+            conn = await pool_used.getconn()
+            await _ping_connection(conn)
+            yield conn
+            return
+        except (OperationalError, InterfaceError) as e:
+            if conn is not None:
+                try:
+                    await conn.close()
+                except Exception:
+                    pass
+
+            if recreate_pool is None or attempt == 1:
+                raise HTTPException(status_code=500, detail=f"Database connection is unavailable: {e}") from e
+
+            current_pool = await recreate_pool()
+        finally:
+            if conn is not None and not getattr(conn, "closed", False):
+                await pool_used.putconn(conn)
+
+    raise HTTPException(status_code=500, detail="Database connection is unavailable")
 
 
 @dataclass(slots=True)

--- a/project/backend/db.py
+++ b/project/backend/db.py
@@ -1,5 +1,7 @@
 import json
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
 
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
@@ -50,7 +52,7 @@ def create_db_pool(conninfo: str, min_size: int = 5, max_size: int = 20) -> Asyn
     return AsyncConnectionPool(conninfo=conninfo, min_size=min_size, max_size=max_size)
 
 
-async def get_db_connection(pool: AsyncConnectionPool | None) -> AsyncGenerator:
+async def get_db_connection(pool: AsyncConnectionPool | None) -> AsyncGenerator[Any, None]:
     if pool is None:
         raise HTTPException(status_code=500, detail="Database pool is not initialized")
 
@@ -61,111 +63,126 @@ async def get_db_connection(pool: AsyncConnectionPool | None) -> AsyncGenerator:
         await pool.putconn(conn)
 
 
-async def delete_saved_post_by_id(conn, item_id: int) -> None:
-    async with conn.cursor() as cursor:
-        await cursor.execute("DELETE FROM saved_posts WHERE id = %s", (item_id,))
+@dataclass(slots=True)
+class SavedPostsRepository:
+    conn: Any
+
+    async def delete_by_id(self, item_id: int) -> None:
+        async with self.conn.cursor() as cursor:
+            await cursor.execute("DELETE FROM saved_posts WHERE id = %s", (item_id,))
+
+    async def create_processing_item(self, user_id: str, post_url: str) -> int:
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(
+                """
+                INSERT INTO saved_posts (user_id, source_url, category, title, vibe_text, image_url, facts)
+                VALUES (%s, %s, 'PROCESSING ', '분석 중...', 'AI가 열심히 바이브를 추출하고 있어요', '', '{}')
+                RETURNING id
+                """,
+                (user_id, post_url),
+            )
+            new_item_id = (await cursor.fetchone())[0]
+            await self.conn.commit()
+            return new_item_id
+
+    async def count_by_user_id(self, user_id: str) -> int:
+        async with self.conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute("SELECT COUNT(*) AS count FROM saved_posts WHERE user_id = %s", (user_id,))
+            row = await cursor.fetchone()
+            return row["count"] if row else 0
+
+    async def create_manual_item(
+        self,
+        user_id: str,
+        url: str,
+        category: str,
+        vibe: str,
+        facts: dict,
+        image_url: str = "",
+    ) -> None:
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(
+                """
+                INSERT INTO saved_posts (user_id, source_url, category, vibe_text, facts, title, image_url)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    user_id,
+                    url,
+                    category,
+                    vibe,
+                    json.dumps(facts),
+                    facts.get("title", "Manual Item"),
+                    image_url,
+                ),
+            )
+            await self.conn.commit()
+
+    async def list_feed_items(self, user_id: str):
+        async with self.conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute(
+                """
+                SELECT
+                    id,
+                    source_url as url,
+                    category,
+                    facts,
+                    vibe_text as vibe,
+                    image_url,
+                    summary_text,
+                    created_at
+                FROM saved_posts
+                WHERE user_id = %s OR user_id = 'default_user'
+                ORDER BY created_at DESC
+                """,
+                (user_id,),
+            )
+            items = await cursor.fetchall()
+            return jsonable_encoder(items)
 
 
-async def create_processing_item(conn, user_id: str, post_url: str) -> int:
-    async with conn.cursor() as cursor:
-        await cursor.execute(
-            """
-            INSERT INTO saved_posts (user_id, source_url, category, title, vibe_text, image_url, facts)
-            VALUES (%s, %s, 'PROCESSING ', '분석 중...', 'AI가 열심히 바이브를 추출하고 있어요', '', '{}')
-            RETURNING id
-            """,
-            (user_id, post_url),
-        )
-        new_item_id = (await cursor.fetchone())[0]
-        await conn.commit()
-        return new_item_id
+@dataclass(slots=True)
+class TasteProfileRepository:
+    conn: Any
+
+    async def get_latest_summary(self) -> str | None:
+        async with self.conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute(
+                "SELECT summary FROM taste_profile WHERE id = 1 ORDER BY updated_at DESC LIMIT 1"
+            )
+            row = await cursor.fetchone()
+            return row["summary"] if row else None
+
+    async def upsert_summary(self, summary: str) -> None:
+        async with self.conn.cursor() as cursor:
+            await cursor.execute(
+                """
+                INSERT INTO taste_profile (id, summary, updated_at)
+                VALUES (1, %s, CURRENT_TIMESTAMP)
+                ON CONFLICT (id)
+                DO UPDATE SET
+                    summary = EXCLUDED.summary,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (summary,),
+            )
+            await self.conn.commit()
+
+    async def get_profile(self):
+        async with self.conn.cursor(row_factory=dict_row) as cursor:
+            await cursor.execute("SELECT * FROM taste_profile WHERE id = 1")
+            row = await cursor.fetchone()
+            return row if row else {"summary": ""}
 
 
-async def count_saved_posts(conn, user_id: str) -> int:
-    async with conn.cursor(row_factory=dict_row) as cursor:
-        await cursor.execute("SELECT COUNT(*) AS count FROM saved_posts WHERE user_id = %s", (user_id,))
-        row = await cursor.fetchone()
-        return row["count"] if row else 0
+@dataclass(slots=True)
+class Repositories:
+    saved_posts: SavedPostsRepository
+    taste_profile: TasteProfileRepository
 
 
-async def get_latest_taste_summary(conn) -> str | None:
-    async with conn.cursor(row_factory=dict_row) as cursor:
-        await cursor.execute(
-            "SELECT summary FROM taste_profile WHERE id = 1 ORDER BY updated_at DESC LIMIT 1"
-        )
-        row = await cursor.fetchone()
-        return row["summary"] if row else None
-
-
-async def upsert_taste_profile(conn, summary: str) -> None:
-    async with conn.cursor() as cursor:
-        await cursor.execute(
-            """
-            INSERT INTO taste_profile (id, summary, updated_at)
-            VALUES (1, %s, CURRENT_TIMESTAMP)
-            ON CONFLICT (id)
-            DO UPDATE SET
-                summary = EXCLUDED.summary,
-                updated_at = CURRENT_TIMESTAMP
-            """,
-            (summary,),
-        )
-        await conn.commit()
-
-
-async def create_manual_item(
-    conn,
-    user_id: str,
-    url: str,
-    category: str,
-    vibe: str,
-    facts: dict,
-    image_url: str = "",
-) -> None:
-    async with conn.cursor() as cursor:
-        await cursor.execute(
-            """
-            INSERT INTO saved_posts (user_id, source_url, category, vibe_text, facts, title, image_url)
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
-            """,
-            (
-                user_id,
-                url,
-                category,
-                vibe,
-                json.dumps(facts),
-                facts.get("title", "Manual Item"),
-                image_url,
-            ),
-        )
-        await conn.commit()
-
-
-async def fetch_items(conn, user_id: str):
-    async with conn.cursor(row_factory=dict_row) as cursor:
-        await cursor.execute(
-            """
-            SELECT
-                id,
-                source_url as url,
-                category,
-                facts,
-                vibe_text as vibe,
-                image_url,
-                summary_text,
-                created_at
-            FROM saved_posts
-            WHERE user_id = %s OR user_id = 'default_user'
-            ORDER BY created_at DESC
-            """,
-            (user_id,),
-        )
-        items = await cursor.fetchall()
-        return jsonable_encoder(items)
-
-
-async def fetch_taste_profile(conn):
-    async with conn.cursor(row_factory=dict_row) as cursor:
-        await cursor.execute("SELECT * FROM taste_profile WHERE id = 1")
-        row = await cursor.fetchone()
-        return row if row else {"summary": ""}
+def get_repositories(conn: Any) -> Repositories:
+    return Repositories(
+        saved_posts=SavedPostsRepository(conn),
+        taste_profile=TasteProfileRepository(conn),
+    )

--- a/project/backend/db.py
+++ b/project/backend/db.py
@@ -1,0 +1,171 @@
+import json
+from collections.abc import AsyncGenerator
+
+from fastapi import HTTPException
+from fastapi.encoders import jsonable_encoder
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
+
+
+async def init_db(db_pool: AsyncConnectionPool) -> None:
+    """비동기 방식으로 DB 테이블 스키마를 초기화"""
+    try:
+        async with db_pool.connection() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS saved_posts (
+                        id SERIAL PRIMARY KEY,
+                        user_id TEXT,
+                        source_url TEXT,
+                        title TEXT,
+                        category TEXT,
+                        summary_text TEXT,
+                        image_url TEXT,
+                        vibe_text TEXT,
+                        vibe_vector vector(768),
+                        facts JSONB,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        UNIQUE(source_url, title)
+                    );
+                    """
+                )
+                await cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS taste_profile (
+                        id INTEGER PRIMARY KEY DEFAULT 1,
+                        summary TEXT,
+                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT one_row CHECK (id = 1)
+                    );
+                    """
+                )
+                await conn.commit()
+        print("DB 테이블 초기화 완료")
+    except Exception as e:
+        print(f"DB 초기화 중 경고: {e}")
+
+
+def create_db_pool(conninfo: str, min_size: int = 5, max_size: int = 20) -> AsyncConnectionPool:
+    return AsyncConnectionPool(conninfo=conninfo, min_size=min_size, max_size=max_size)
+
+
+async def get_db_connection(pool: AsyncConnectionPool | None) -> AsyncGenerator:
+    if pool is None:
+        raise HTTPException(status_code=500, detail="Database pool is not initialized")
+
+    conn = await pool.getconn()
+    try:
+        yield conn
+    finally:
+        await pool.putconn(conn)
+
+
+async def delete_saved_post_by_id(conn, item_id: int) -> None:
+    async with conn.cursor() as cursor:
+        await cursor.execute("DELETE FROM saved_posts WHERE id = %s", (item_id,))
+
+
+async def create_processing_item(conn, user_id: str, post_url: str) -> int:
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            """
+            INSERT INTO saved_posts (user_id, source_url, category, title, vibe_text, image_url, facts)
+            VALUES (%s, %s, 'PROCESSING ', '분석 중...', 'AI가 열심히 바이브를 추출하고 있어요', '', '{}')
+            RETURNING id
+            """,
+            (user_id, post_url),
+        )
+        new_item_id = (await cursor.fetchone())[0]
+        await conn.commit()
+        return new_item_id
+
+
+async def count_saved_posts(conn, user_id: str) -> int:
+    async with conn.cursor(row_factory=dict_row) as cursor:
+        await cursor.execute("SELECT COUNT(*) AS count FROM saved_posts WHERE user_id = %s", (user_id,))
+        row = await cursor.fetchone()
+        return row["count"] if row else 0
+
+
+async def get_latest_taste_summary(conn) -> str | None:
+    async with conn.cursor(row_factory=dict_row) as cursor:
+        await cursor.execute(
+            "SELECT summary FROM taste_profile WHERE id = 1 ORDER BY updated_at DESC LIMIT 1"
+        )
+        row = await cursor.fetchone()
+        return row["summary"] if row else None
+
+
+async def upsert_taste_profile(conn, summary: str) -> None:
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            """
+            INSERT INTO taste_profile (id, summary, updated_at)
+            VALUES (1, %s, CURRENT_TIMESTAMP)
+            ON CONFLICT (id)
+            DO UPDATE SET
+                summary = EXCLUDED.summary,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (summary,),
+        )
+        await conn.commit()
+
+
+async def create_manual_item(
+    conn,
+    user_id: str,
+    url: str,
+    category: str,
+    vibe: str,
+    facts: dict,
+    image_url: str = "",
+) -> None:
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            """
+            INSERT INTO saved_posts (user_id, source_url, category, vibe_text, facts, title, image_url)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                user_id,
+                url,
+                category,
+                vibe,
+                json.dumps(facts),
+                facts.get("title", "Manual Item"),
+                image_url,
+            ),
+        )
+        await conn.commit()
+
+
+async def fetch_items(conn, user_id: str):
+    async with conn.cursor(row_factory=dict_row) as cursor:
+        await cursor.execute(
+            """
+            SELECT
+                id,
+                source_url as url,
+                category,
+                facts,
+                vibe_text as vibe,
+                image_url,
+                summary_text,
+                created_at
+            FROM saved_posts
+            WHERE user_id = %s OR user_id = 'default_user'
+            ORDER BY created_at DESC
+            """,
+            (user_id,),
+        )
+        items = await cursor.fetchall()
+        return jsonable_encoder(items)
+
+
+async def fetch_taste_profile(conn):
+    async with conn.cursor(row_factory=dict_row) as cursor:
+        await cursor.execute("SELECT * FROM taste_profile WHERE id = 1")
+        row = await cursor.fetchone()
+        return row if row else {"summary": ""}


### PR DESCRIPTION
## Summary
- `main.py`에 섞여 있던 DB 초기화/쿼리 로직을 `project/backend/db.py`로 분리했습니다.
- `saved_posts`, `taste_profile` 중심의 Repository 계층과 FastAPI dependency 주입을 추가해 엔드포인트 가독성을 높였습니다.
- serverless DB idle 이후 stale connection이 남을 수 있는 상황을 대비해 ping 및 pool 재생성 후 재시도 로직을 추가했습니다.

## Changes
- `project/backend/db.py` 신설
- DB schema 초기화, connection dependency, repository 로직을 `db.py`로 이동
- `SavedPostsRepository`, `TasteProfileRepository`, `Repositories` 도입
- `main.py`에서 raw SQL 대신 repository 호출 사용
- `get_repos()` dependency를 추가해 엔드포인트에서 repository를 직접 주입받도록 변경
- `get_db_connection()`에서 `SELECT 1` ping 수행
- ping 실패 시 pool을 재생성하고 connection 획득을 1회 재시도하도록 변경
- `main.py`에 `rebuild_db_pool()` 추가

## Why
- `main.py`에 백엔드 흐름과 DB 세부 구현이 섞여 있어 읽기 어려웠습니다.
- DB 접근을 한곳으로 모아 책임을 분리하고, 이후 유지보수와 테스트를 쉽게 하려는 목적입니다.
- long-lived backend + serverless DB 조합에서 idle 이후 stale connection 문제가 발생할 수 있어 방어 로직이 필요했습니다.

## Validation
- `python -m py_compile main.py project/backend/db.py`

## 논의 할 점
- long-lived backend + serverless DB 조합이여서 저런 pool rebuild 조합이 필요함.
- 일반적으로 사용되는 long-lived backend + long-lived DB  또는 serverless Backend + serverless DB면 이 문제 안생김.
- 지금 저런 구조인 이유는.. backgroundTask를 다른 Computer가 아닌 백엔드 자체에서 실행하기 때문에.. 백엔드가 long-lived로 고정되어서 생김.
- 잘 생각해보셈요.