### PR TITLE
[codex] Refactor frontend data flow and extract feed/search cards

### DIFF
--- a/project/frontend/package-lock.json
+++ b/project/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/vite": "^4.1.14",
+        "@tanstack/react-query": "^5.96.2",
         "@vitejs/plugin-react": "^5.0.4",
         "axios": "^1.13.6",
         "bcryptjs": "^3.0.3",
@@ -1912,6 +1913,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
+      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
+      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/project/frontend/package.json
+++ b/project/frontend/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/vite": "^4.1.14",
+    "@tanstack/react-query": "^5.96.2",
     "@vitejs/plugin-react": "^5.0.4",
     "axios": "^1.13.6",
     "bcryptjs": "^3.0.3",

--- a/project/frontend/src/components/FeedItemCard.tsx
+++ b/project/frontend/src/components/FeedItemCard.tsx
@@ -1,0 +1,93 @@
+import { motion } from 'framer-motion';
+import { Trash2, Instagram, Sparkles } from 'lucide-react';
+
+import type { SavedItem } from '../types/item';
+
+type FeedItemCardProps = {
+  item: SavedItem;
+  factKeysToShow: string[];
+  onDelete: (id: number) => void | Promise<void>;
+  onSelect: () => void;
+};
+
+export function FeedItemCard({
+  item,
+  factKeysToShow,
+  onDelete,
+  onSelect,
+}: FeedItemCardProps) {
+  return (
+    <motion.div
+      layout
+      onClick={onSelect}
+      className="break-inside-avoid group relative bg-white rounded-3xl overflow-hidden border border-black/5 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 cursor-pointer"
+    >
+      <div className="relative overflow-hidden">
+        <img
+          src={item.image_url?.startsWith('http') || item.image_url?.startsWith('data:') || item.image_url?.startsWith('//') ? item.image_url : item.image_url ? `/api/images/${item.image_url}` : 'https://via.placeholder.com/400x500?text=No+Image'}
+          alt={item.category}
+          className="w-full h-auto object-cover transform group-hover:scale-105 transition-transform duration-700"
+          referrerPolicy="no-referrer"
+          onError={(e) => {
+            (e.target as HTMLImageElement).src = 'https://via.placeholder.com/400x500?text=POSE+Not+Found';
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+      </div>
+      <div className="p-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-[9px] font-black uppercase tracking-widest text-blue-600 bg-blue-50 px-2 py-1 rounded-md">
+            {item.category}
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(item.id);
+            }}
+            className="opacity-0 group-hover:opacity-100 p-1.5 bg-red-50 text-red-500 rounded-full hover:bg-red-100 transition-all"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
+        </div>
+        <p className="text-sm font-bold leading-tight line-clamp-2 text-black">{item.vibe}</p>
+
+        {item.facts && typeof item.facts === 'object' && (
+          <>
+            {Object.entries(item.facts).filter(([key]) => factKeysToShow.includes(key.toLowerCase())).length > 0 && (
+              <div className="space-y-1.5 mt-3 border-t border-gray-100 pt-3">
+                {Object.entries(item.facts)
+                  .filter(([key]) => factKeysToShow.includes(key.toLowerCase()))
+                  .map(([key, value]) => (
+                    <div key={key} className="flex flex-col gap-0.5">
+                      <span className="text-[8px] font-black text-gray-400 uppercase tracking-widest">{key.replace(/_/g, ' ')}</span>
+                      <p className="text-[11px] text-gray-600 line-clamp-1 font-medium">
+                        {Array.isArray(value) ? value.join(', ') : String(value)}
+                      </p>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="pt-3 flex items-center gap-2">
+          {item.url && item.url.startsWith('http') ? (
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="text-[10px] font-bold text-gray-400 hover:text-black flex items-center gap-1 transition-colors"
+            >
+              <Instagram className="w-3 h-3" /> View Source
+            </a>
+          ) : (
+            <span className="text-[10px] font-bold text-gray-400 flex items-center gap-1">
+              <Sparkles className="w-3 h-3" /> AI Curated
+            </span>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/project/frontend/src/components/FeedTabContent.tsx
+++ b/project/frontend/src/components/FeedTabContent.tsx
@@ -1,9 +1,10 @@
 import { motion } from 'framer-motion';
-import { Plus, Loader2, Trash2, Instagram, Sparkles, Zap } from 'lucide-react';
+import { Plus, Loader2, Zap } from 'lucide-react';
 import { useMemo, useState, type FormEvent } from 'react';
 
 import type { SavedItem } from '../types/item';
 import type { AppUser } from '../types/user';
+import { FeedItemCard } from './FeedItemCard';
 
 type FeedTabContentProps = {
   items: SavedItem[];
@@ -168,79 +169,13 @@ export function FeedTabContent({
 
       <div className="columns-2 md:columns-3 lg:columns-4 gap-4 space-y-4 mt-4">
         {filteredItems.map((item) => (
-          <motion.div
-            layout
+          <FeedItemCard
             key={item.id}
-            onClick={() => onSelectItem(item)}
-            className="break-inside-avoid group relative bg-white rounded-3xl overflow-hidden border border-black/5 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 cursor-pointer"
-          >
-            <div className="relative overflow-hidden">
-              <img
-                src={item.image_url?.startsWith('http') || item.image_url?.startsWith('data:') || item.image_url?.startsWith('//') ? item.image_url : item.image_url ? `/api/images/${item.image_url}` : 'https://via.placeholder.com/400x500?text=No+Image'}
-                alt={item.category}
-                className="w-full h-auto object-cover transform group-hover:scale-105 transition-transform duration-700"
-                referrerPolicy="no-referrer"
-                onError={(e) => {
-                  (e.target as HTMLImageElement).src = 'https://via.placeholder.com/400x500?text=POSE+Not+Found';
-                }}
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-            </div>
-            <div className="p-4 space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-[9px] font-black uppercase tracking-widest text-blue-600 bg-blue-50 px-2 py-1 rounded-md">
-                  {item.category}
-                </span>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDelete(item.id);
-                  }}
-                  className="opacity-0 group-hover:opacity-100 p-1.5 bg-red-50 text-red-500 rounded-full hover:bg-red-100 transition-all"
-                >
-                  <Trash2 className="w-3 h-3" />
-                </button>
-              </div>
-              <p className="text-sm font-bold leading-tight line-clamp-2 text-black">{item.vibe}</p>
-
-              {item.facts && typeof item.facts === 'object' && (
-                <>
-                  {Object.entries(item.facts).filter(([key]) => factKeysToShow.includes(key.toLowerCase())).length > 0 && (
-                    <div className="space-y-1.5 mt-3 border-t border-gray-100 pt-3">
-                      {Object.entries(item.facts)
-                        .filter(([key]) => factKeysToShow.includes(key.toLowerCase()))
-                        .map(([key, value]) => (
-                          <div key={key} className="flex flex-col gap-0.5">
-                            <span className="text-[8px] font-black text-gray-400 uppercase tracking-widest">{key.replace(/_/g, ' ')}</span>
-                            <p className="text-[11px] text-gray-600 line-clamp-1 font-medium">
-                              {Array.isArray(value) ? value.join(', ') : String(value)}
-                            </p>
-                          </div>
-                        ))}
-                    </div>
-                  )}
-                </>
-              )}
-
-              <div className="pt-3 flex items-center gap-2">
-                {item.url && item.url.startsWith('http') ? (
-                  <a
-                    href={item.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="text-[10px] font-bold text-gray-400 hover:text-black flex items-center gap-1 transition-colors"
-                  >
-                    <Instagram className="w-3 h-3" /> View Source
-                  </a>
-                ) : (
-                  <span className="text-[10px] font-bold text-gray-400 flex items-center gap-1">
-                    <Sparkles className="w-3 h-3" /> AI Curated
-                  </span>
-                )}
-              </div>
-            </div>
-          </motion.div>
+            factKeysToShow={factKeysToShow}
+            item={item}
+            onDelete={handleDelete}
+            onSelect={() => onSelectItem(item)}
+          />
         ))}
       </div>
 

--- a/project/frontend/src/components/FeedTabContent.tsx
+++ b/project/frontend/src/components/FeedTabContent.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { Plus, Loader2, Zap } from 'lucide-react';
 import { useMemo, useState, type FormEvent } from 'react';
@@ -26,7 +27,6 @@ export function FeedTabContent({
   const [newUrl, setNewUrl] = useState("");
   const [sessionId, setSessionId] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string>('All');
-  const [loading, setLoading] = useState(false);
 
   const factKeysToShow = ['title', 'price_info', 'location_text', 'time_info', 'key_details'];
   const categories = useMemo(
@@ -38,15 +38,12 @@ export function FeedTabContent({
     [items, selectedCategory]
   );
 
-  const handleAddItem = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!newUrl || !user) return;
-    setLoading(true);
-    try {
+  const addItemMutation = useMutation({
+    mutationFn: async ({ nextUrl, nextSessionId, userId }: { nextUrl: string; nextSessionId: string; userId: number }) => {
       const res = await fetch('/api/extract-url', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: newUrl, session_id: sessionId, user_id: user.id })
+        body: JSON.stringify({ url: nextUrl, session_id: nextSessionId, user_id: userId })
       });
 
       if (!res.ok) {
@@ -54,13 +51,18 @@ export function FeedTabContent({
         throw new Error(error.detail || "Failed to analyze URL");
       }
 
-      const responseData = await res.json();
-      if (responseData.success && responseData.status === 'processing') {
-        alert(`✨ ${responseData.message}`);
-      } else if (responseData.success && responseData.data && Array.isArray(responseData.data)) {
-        const newItems = responseData.data.map((item: any, index: number) => ({
+      return {
+        nextUrl,
+        data: await res.json(),
+      };
+    },
+    onSuccess: ({ nextUrl, data }) => {
+      if (data.success && data.status === 'processing') {
+        alert(`✨ ${data.message}`);
+      } else if (data.success && data.data && Array.isArray(data.data)) {
+        const newItems = data.data.map((item: any, index: number) => ({
           id: Date.now() + index,
-          url: newUrl,
+          url: nextUrl,
           category: item.category || 'General',
           facts: item.facts || {},
           vibe: item.vibe_text || 'Extracted',
@@ -68,7 +70,7 @@ export function FeedTabContent({
           created_at: new Date().toISOString(),
           summary_text: item.summary_text || ''
         }));
-        onItemsChange([...newItems, ...items]);
+        onItemsChange((prev) => [...newItems, ...prev]);
       }
 
       setNewUrl("");
@@ -78,30 +80,52 @@ export function FeedTabContent({
         void refreshItems();
         void refreshTaste();
       }, 3000);
-
-    } catch (error: any) {
+    },
+    onError: (error: Error) => {
       console.error(error);
       alert(`분석 요청 중 오류가 발생했습니다: ${error.message}`);
-    } finally {
-      setLoading(false);
-    }
+    },
+  });
+
+  const deleteItemMutation = useMutation({
+    mutationFn: async ({ id, userId }: { id: number; userId: number }) => {
+      const res = await fetch(`/api/items/${id}?user_id=${userId}`, { method: 'DELETE' });
+
+      if (!res.ok) {
+        throw new Error('Failed to delete item');
+      }
+
+      return id;
+    },
+    onMutate: async ({ id }) => {
+      const previousItems = items;
+      onItemsChange((currentItems) => currentItems.filter((item) => item.id !== id));
+      return { previousItems };
+    },
+    onError: (error, _variables, context) => {
+      console.error('Delete failed:', error);
+      if (context?.previousItems) {
+        onItemsChange(context.previousItems);
+      }
+      alert('삭제 중 오류가 발생했습니다.');
+    },
+  });
+
+  const handleAddItem = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newUrl || !user) return;
+    await addItemMutation.mutateAsync({
+      nextSessionId: sessionId,
+      nextUrl: newUrl,
+      userId: user.id,
+    });
   };
 
   const handleDelete = async (id: number) => {
     if (!user) return;
     const shouldDelete = window.confirm('정말로 삭제하십니까?');
     if (!shouldDelete) return;
-
-    const previousItems = items;
-    onItemsChange((currentItems) => currentItems.filter((item) => item.id !== id));
-
-    try {
-      await fetch(`/api/items/${id}?user_id=${user.id}`, { method: 'DELETE' });
-    } catch (error) {
-      console.error('Delete failed:', error);
-      onItemsChange(previousItems);
-      alert('삭제 중 오류가 발생했습니다.');
-    }
+    await deleteItemMutation.mutateAsync({ id, userId: user.id });
   };
 
   return (
@@ -139,10 +163,10 @@ export function FeedTabContent({
             />
           </div>
           <button
-            disabled={loading}
+            disabled={addItemMutation.isPending}
             className="w-full sm:w-auto px-8 py-3 bg-black text-white rounded-2xl hover:bg-gray-800 hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:transform-none transition-all flex items-center justify-center gap-2 text-sm font-black tracking-widest uppercase h-[44px]"
           >
-            {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+            {addItemMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
             Add
           </button>
         </form>
@@ -179,7 +203,7 @@ export function FeedTabContent({
         ))}
       </div>
 
-      {items.length === 0 && !loading && (
+      {items.length === 0 && !addItemMutation.isPending && (
         <div className="text-center py-32 bg-gray-50 rounded-[3rem] border-2 border-dashed border-gray-200">
           <div className="w-20 h-20 bg-white rounded-full flex items-center justify-center mx-auto mb-6 shadow-sm">
             <Zap className="w-10 h-10 text-yellow-400" fill="currentColor" />

--- a/project/frontend/src/components/SearchResultCard.tsx
+++ b/project/frontend/src/components/SearchResultCard.tsx
@@ -1,0 +1,70 @@
+import { motion } from 'framer-motion';
+
+import type { SavedItem } from '../types/item';
+
+type SearchResultCardProps = {
+  item: SavedItem;
+  delay: number;
+  onClick: () => void;
+  onSave: (e: React.MouseEvent<HTMLButtonElement>, item: SavedItem) => void | Promise<void>;
+};
+
+export function SearchResultCard({
+  item,
+  delay,
+  onClick,
+  onSave,
+}: SearchResultCardProps) {
+  const factsObj = typeof item.facts === 'string' ? JSON.parse(item.facts) : item.facts;
+  const title = factsObj?.title || item.summary_text || '제목 없음';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay, duration: 0.3 }}
+      onClick={onClick}
+      className="group bg-white rounded-3xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-300 cursor-pointer border border-gray-100 flex flex-col h-full"
+    >
+      <div className="aspect-square w-full bg-gray-100 overflow-hidden relative">
+        {item.image_url ? (
+          <img
+            src={item.image_url}
+            alt={title}
+            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            referrerPolicy="no-referrer"
+            onError={(e) => {
+              (e.target as HTMLImageElement).src = 'https://via.placeholder.com/400x400?text=No+Image';
+            }}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-400 text-xs font-bold bg-gray-50">
+            No Image
+          </div>
+        )}
+        <div className="absolute top-3 left-3">
+          <span className="inline-block text-[10px] font-black uppercase tracking-widest text-white bg-black/80 backdrop-blur-md px-2.5 py-1 rounded-lg">
+            {item.category}
+          </span>
+        </div>
+      </div>
+
+      <div className="p-5 flex flex-col flex-1">
+        <h3 className="font-bold text-black text-sm line-clamp-2 mb-2 leading-snug">
+          {title}
+        </h3>
+        <p className="text-xs text-gray-500 line-clamp-2 mb-4">
+          {item.summary_text}
+        </p>
+        <div className="mt-auto">
+          <button
+            onClick={(e) => onSave(e, item)}
+            className="w-full py-2.5 bg-gray-50 hover:bg-black hover:text-white text-black rounded-xl text-xs font-black uppercase tracking-widest transition-colors flex items-center justify-center gap-2"
+          >
+            + 피드에 저장
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/project/frontend/src/components/SearchTabContent.tsx
+++ b/project/frontend/src/components/SearchTabContent.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import type { SavedItem } from '../types/item';
 import type { AppUser } from '../types/user';
 import { ItemDetailDialog } from './ItemDetailDialog'; 
+import { SearchResultCard } from './SearchResultCard';
 
 type SearchTabContentProps = {
   onItemsChange: React.Dispatch<React.SetStateAction<SavedItem[]>>;
@@ -199,62 +200,14 @@ export function SearchTabContent({
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
                 <AnimatePresence>
                   {searchResults.map((item, index) => {
-                    // 카드가 순차적으로 뜨도록 delay 설정
-                    const delay = index * 0.1;
-                    const factsObj = typeof item.facts === 'string' ? JSON.parse(item.facts) : item.facts;
-                    const title = factsObj?.title || item.summary_text || "제목 없음";
-
                     return (
-                      <motion.div
+                      <SearchResultCard
                         key={item.id}
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay, duration: 0.3 }}
+                        delay={index * 0.1}
+                        item={item}
                         onClick={() => setSelectedItem(item)}
-                        className="group bg-white rounded-3xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-300 cursor-pointer border border-gray-100 flex flex-col h-full"
-                      >
-                        {/* 썸네일 영역 */}
-                        <div className="aspect-square w-full bg-gray-100 overflow-hidden relative">
-                          {item.image_url ? (
-                            <img
-                              src={item.image_url}
-                              alt={title}
-                              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
-                              referrerPolicy="no-referrer"
-                              onError={(e) => {
-                                (e.target as HTMLImageElement).src = 'https://via.placeholder.com/400x400?text=No+Image';
-                              }}
-                            />
-                          ) : (
-                            <div className="w-full h-full flex items-center justify-center text-gray-400 text-xs font-bold bg-gray-50">
-                              No Image
-                            </div>
-                          )}
-                          <div className="absolute top-3 left-3">
-                            <span className="inline-block text-[10px] font-black uppercase tracking-widest text-white bg-black/80 backdrop-blur-md px-2.5 py-1 rounded-lg">
-                              {item.category}
-                            </span>
-                          </div>
-                        </div>
-
-                        {/* 텍스트 정보 영역 */}
-                        <div className="p-5 flex flex-col flex-1">
-                          <h3 className="font-bold text-black text-sm line-clamp-2 mb-2 leading-snug">
-                            {title}
-                          </h3>
-                          <p className="text-xs text-gray-500 line-clamp-2 mb-4">
-                            {item.summary_text}
-                          </p>
-                          <div className="mt-auto">
-                            <button
-                              onClick={(e) => handleSaveToFeed(e, item)}
-                              className="w-full py-2.5 bg-gray-50 hover:bg-black hover:text-white text-black rounded-xl text-xs font-black uppercase tracking-widest transition-colors flex items-center justify-center gap-2"
-                            >
-                              + 피드에 저장
-                            </button>
-                          </div>
-                        </div>
-                      </motion.div>
+                        onSave={handleSaveToFeed}
+                      />
                     );
                   })}
                 </AnimatePresence>

--- a/project/frontend/src/main.tsx
+++ b/project/frontend/src/main.tsx
@@ -1,10 +1,15 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
+const queryClient = new QueryClient();
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## What changed
- extracted the search result card UI into a dedicated `SearchResultCard` component
- extracted the feed masonry card UI into a dedicated `FeedItemCard` component
- moved frontend item and taste fetching into custom hooks to simplify `App.tsx`
- added `@tanstack/react-query` and wrapped the app with `QueryClientProvider`
- converted feed add/delete requests in `FeedTabContent` to `useMutation`
- kept the existing optimistic delete behavior and post-add refresh flow while moving request state into TanStack Query

## Why
The frontend tab components had started to hold both layout and request logic in the same file, which made them harder to read and change. This refactor separates repeated card rendering from container logic and starts moving async request handling toward a more maintainable pattern.

## Impact
- `FeedTabContent` is smaller and focused on filtering, form handling, and passing callbacks
- `SearchTabContent` is smaller and focused on search state and dialog control
- add/delete loading and error handling for feed items now live in mutation lifecycle callbacks instead of manual local loading state
- the app now has the base React Query setup needed for future query/mutation expansion

## Validation
- ran `npm run build` in `project/frontend`
