### PR TITLE
[codex] Refine feed card titles and layout

### DIFF
--- a/project/frontend/src/components/FeedItemCard.tsx
+++ b/project/frontend/src/components/FeedItemCard.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { Trash2, Instagram, Sparkles } from 'lucide-react';
 
+import { getItemTitle, parseItemFacts } from '../lib/itemFacts';
 import type { SavedItem } from '../types/item';
 
 type FeedItemCardProps = {
@@ -16,6 +17,9 @@ export function FeedItemCard({
   onDelete,
   onSelect,
 }: FeedItemCardProps) {
+  const facts = parseItemFacts(item);
+  const title = getItemTitle(item);
+
   return (
     <motion.div
       layout
@@ -49,13 +53,13 @@ export function FeedItemCard({
             <Trash2 className="w-3 h-3" />
           </button>
         </div>
-        <p className="text-sm font-bold leading-tight line-clamp-2 text-black">{item.recommend}</p>
+        <p className="text-sm font-bold leading-tight line-clamp-2 text-black">{title}</p>
 
-        {item.facts && typeof item.facts === 'object' && (
+        {facts && (
           <>
-            {Object.entries(item.facts).filter(([key]) => factKeysToShow.includes(key.toLowerCase())).length > 0 && (
+            {Object.entries(facts).filter(([key]) => factKeysToShow.includes(key.toLowerCase())).length > 0 && (
               <div className="space-y-1.5 mt-3 border-t border-gray-100 pt-3">
-                {Object.entries(item.facts)
+                {Object.entries(facts)
                   .filter(([key]) => factKeysToShow.includes(key.toLowerCase()))
                   .map(([key, value]) => (
                     <div key={key} className="flex flex-col gap-0.5">

--- a/project/frontend/src/components/FeedItemCard.tsx
+++ b/project/frontend/src/components/FeedItemCard.tsx
@@ -19,18 +19,23 @@ export function FeedItemCard({
 }: FeedItemCardProps) {
   const facts = parseItemFacts(item);
   const title = getItemTitle(item);
+  const visibleFacts = facts
+    ? Object.entries(facts).filter(
+        ([key]) => key.toLowerCase() !== 'title' && factKeysToShow.includes(key.toLowerCase())
+      )
+    : [];
 
   return (
     <motion.div
       layout
       onClick={onSelect}
-      className="break-inside-avoid group relative bg-white rounded-3xl overflow-hidden border border-black/5 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 cursor-pointer"
+      className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-black/5 bg-white transition-all duration-300 cursor-pointer hover:-translate-y-1 hover:shadow-2xl"
     >
-      <div className="relative overflow-hidden">
+      <div className="relative aspect-[4/4.6] overflow-hidden bg-gray-100">
         <img
           src={item.image_url?.startsWith('http') || item.image_url?.startsWith('data:') || item.image_url?.startsWith('//') ? item.image_url : item.image_url ? `/api/images/${item.image_url}` : 'https://via.placeholder.com/400x500?text=No+Image'}
           alt={item.category}
-          className="w-full h-auto object-cover transform group-hover:scale-105 transition-transform duration-700"
+          className="h-full w-full object-cover transform transition-transform duration-700 group-hover:scale-105"
           referrerPolicy="no-referrer"
           onError={(e) => {
             (e.target as HTMLImageElement).src = 'https://via.placeholder.com/400x500?text=POSE+Not+Found';
@@ -38,7 +43,7 @@ export function FeedItemCard({
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
       </div>
-      <div className="p-4 space-y-2">
+      <div className="flex flex-1 flex-col p-4">
         <div className="flex items-center justify-between">
           <span className="text-[9px] font-black uppercase tracking-widest text-blue-600 bg-blue-50 px-2 py-1 rounded-md">
             {item.category}
@@ -53,28 +58,28 @@ export function FeedItemCard({
             <Trash2 className="w-3 h-3" />
           </button>
         </div>
-        <p className="text-sm font-bold leading-tight line-clamp-2 text-black">{title}</p>
+        <p className="mt-2 text-sm font-bold leading-tight line-clamp-2 text-black">{title}</p>
 
-        {facts && (
-          <>
-            {Object.entries(facts).filter(([key]) => factKeysToShow.includes(key.toLowerCase())).length > 0 && (
-              <div className="space-y-1.5 mt-3 border-t border-gray-100 pt-3">
-                {Object.entries(facts)
-                  .filter(([key]) => factKeysToShow.includes(key.toLowerCase()))
-                  .map(([key, value]) => (
-                    <div key={key} className="flex flex-col gap-0.5">
-                      <span className="text-[8px] font-black text-gray-400 uppercase tracking-widest">{key.replace(/_/g, ' ')}</span>
-                      <p className="text-[11px] text-gray-600 line-clamp-1 font-medium">
-                        {Array.isArray(value) ? value.join(', ') : String(value)}
-                      </p>
-                    </div>
-                  ))}
-              </div>
-            )}
-          </>
-        )}
+        <div className="mt-3 min-h-[104px] border-t border-gray-100 pt-3">
+          {visibleFacts.length > 0 ? (
+            <div className="space-y-1.5">
+              {visibleFacts.map(([key, value]) => (
+                <div key={key} className="flex flex-col gap-0.5">
+                  <span className="text-[8px] font-black text-gray-400 uppercase tracking-widest">{key.replace(/_/g, ' ')}</span>
+                  <p className="text-[11px] text-gray-600 line-clamp-1 font-medium">
+                    {Array.isArray(value) ? value.join(', ') : String(value)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-full items-center">
+              <p className="text-[11px] font-medium text-gray-300">No extracted details</p>
+            </div>
+          )}
+        </div>
 
-        <div className="pt-3 flex items-center gap-2">
+        <div className="mt-auto pt-3 flex items-center gap-2">
           {item.url && item.url.startsWith('http') ? (
             <a
               href={item.url}

--- a/project/frontend/src/components/FeedTabContent.tsx
+++ b/project/frontend/src/components/FeedTabContent.tsx
@@ -191,7 +191,7 @@ export function FeedTabContent({
         </div>
       )}
 
-      <div className="columns-2 md:columns-3 lg:columns-4 gap-4 space-y-4 mt-4">
+      <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4 items-stretch">
         {filteredItems.map((item) => (
           <FeedItemCard
             key={item.id}

--- a/project/frontend/src/components/ItemDetailDialog.tsx
+++ b/project/frontend/src/components/ItemDetailDialog.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Instagram, X, Zap } from 'lucide-react';
 
+import { getItemTitle, parseItemFacts } from '../lib/itemFacts';
 import type { SavedItem } from '../types/item';
 
 type ItemDetailDialogProps = {
@@ -9,29 +10,13 @@ type ItemDetailDialogProps = {
   onOpenChange: (open: boolean) => void;
 };
 
-function parseFacts(item: SavedItem) {
-  if (!item.facts) return null;
-  if (typeof item.facts === 'string') {
-    try {
-      return JSON.parse(item.facts);
-    } catch {
-      return null;
-    }
-  }
-  return item.facts;
-}
-
 export function ItemDetailDialog({ item, onOpenChange }: ItemDetailDialogProps) {
   if (!item) {
     return null;
   }
 
-  const facts = parseFacts(item);
-  const modalTitle =
-    (facts && typeof facts === 'object' && 'title' in facts && typeof facts.title === 'string' && facts.title) ||
-    (facts && typeof facts === 'object' && 'Title' in facts && typeof facts.Title === 'string' && facts.Title) ||
-    item.summary_text ||
-    item.recommend;
+  const facts = parseItemFacts(item);
+  const modalTitle = getItemTitle(item);
   const factEntries =
     facts && typeof facts === 'object'
       ? Object.entries(facts).filter(([key]) => key.toLowerCase() !== 'title')

--- a/project/frontend/src/components/ProfileTabContent.tsx
+++ b/project/frontend/src/components/ProfileTabContent.tsx
@@ -11,6 +11,48 @@ type TasteProfileSection = {
   accent: string;
 };
 
+type ProfileTabContentProps = {
+  items: SavedItem[];
+  onGoToFeed: () => void;
+  onSelectItem: (item: SavedItem) => void;
+  onTasteChange: React.Dispatch<React.SetStateAction<string>>;
+  taste: string;
+  user: AppUser | null;
+};
+
+type ProfileHeaderProps = {
+  user: AppUser | null;
+};
+
+type TasteAnalysisHeaderProps = {
+  user: AppUser | null;
+};
+
+type TasteSectionCardProps = {
+  section: TasteProfileSection;
+};
+
+type TasteSummaryCardProps = {
+  isGeneratingTaste: boolean;
+  isSharingProfile: boolean;
+  onGenerateTaste: () => Promise<void>;
+  onShareProfile: () => Promise<void>;
+  tasteSections: TasteProfileSection[];
+  user: AppUser | null;
+};
+
+type EmptyTasteStateProps = {
+  hasItems: boolean;
+  isGeneratingTaste: boolean;
+  onGenerateTaste: () => Promise<void>;
+  onGoToFeed: () => void;
+};
+
+type RecentInspirationsGridProps = {
+  items: SavedItem[];
+  onSelectItem: (item: SavedItem) => void;
+};
+
 const tasteSectionAccents = [
   'from-purple-500/15 via-pink-500/10 to-transparent border-purple-200/70',
   'from-blue-500/15 via-cyan-500/10 to-transparent border-blue-200/70',
@@ -60,7 +102,10 @@ function buildTasteProfileSections(taste: string): TasteProfileSection[] {
     .map((block) => block.trim())
     .filter(Boolean)
     .map((block, index) => {
-      const lines = block.split('\n').map((line) => line.trim()).filter(Boolean);
+      const lines = block
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
       const [first, ...rest] = lines;
       const headingMatch = first?.match(/^#{1,3}\s+(.*)$/);
       const title = headingMatch ? headingMatch[1] : `Taste Point ${index + 1}`;
@@ -82,14 +127,247 @@ function buildTasteProfileSections(taste: string): TasteProfileSection[] {
     : [{ title: 'Taste Profile', body: [trimmed], accent: tasteSectionAccents[0] }];
 }
 
-type ProfileTabContentProps = {
-  items: SavedItem[];
-  onGoToFeed: () => void;
-  onSelectItem: (item: SavedItem) => void;
-  onTasteChange: React.Dispatch<React.SetStateAction<string>>;
-  taste: string;
-  user: AppUser | null;
-};
+function ProfileHeader({ user }: ProfileHeaderProps) {
+  return (
+    <div className="flex flex-col md:flex-row items-start md:items-end justify-between gap-8 border-b border-black/10 pb-12">
+      <div className="space-y-5">
+        <div className="w-28 h-28 rounded-full bg-gradient-to-tr from-blue-600 via-yellow-300 to-purple-600 p-[3px] shadow-2xl">
+          <div className="w-full h-full bg-white rounded-full flex items-center justify-center overflow-hidden">
+            <User className="w-12 h-12 text-black" />
+          </div>
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-5xl font-black tracking-tighter text-black uppercase">
+            {user?.username || 'Anonymous'}
+          </h2>
+          <p className="text-xs font-black text-gray-400 uppercase tracking-widest bg-gray-100 inline-block px-3 py-1 rounded-full">
+            POSE Creator No. {user?.id || '000'}
+          </p>
+        </div>
+      </div>
+      <div className="text-left md:text-right max-w-xs">
+        <p className="text-2xl font-black text-black leading-tight tracking-tighter uppercase bg-clip-text text-transparent bg-gradient-to-r from-black to-gray-500">
+          "My Vibe is
+          <br />
+          my POSE."
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function TasteAnalysisHeader(_: TasteAnalysisHeaderProps) {
+  return (
+    <div className="lg:col-span-4 space-y-6">
+      <div className="flex items-center gap-3 text-[10px] font-black uppercase tracking-[0.3em] text-blue-600">
+        <Zap className="w-3.5 h-3.5" fill="currentColor" />
+        Taste Analysis
+      </div>
+      <h3 className="text-3xl font-black tracking-tighter leading-none uppercase">
+        The Patterns
+        <br />
+        of your
+        <br />
+        Choices.
+      </h3>
+      <div className="h-2 w-12 bg-black rounded-full" />
+    </div>
+  );
+}
+
+function TasteSectionCard({ section }: TasteSectionCardProps) {
+  return (
+    <div className={`rounded-[2rem] border bg-gradient-to-br ${section.accent} p-6 backdrop-blur-sm`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h5 className="mt-2 text-xl font-black tracking-tight text-black capitalize">
+            {section.title}
+          </h5>
+        </div>
+        <Compass className="h-5 w-5 text-gray-400" />
+      </div>
+      <div className="mt-5 space-y-3">
+        {section.body.map((line, lineIndex) => (
+          <div
+            key={`${section.title}-${lineIndex}`}
+            className="flex gap-3 rounded-2xl bg-white/80 px-4 py-3 shadow-sm shadow-black/5"
+          >
+            <div className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-black" />
+            <p className="text-sm font-medium leading-6 text-gray-700">{line}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TasteSummaryCard({
+  isGeneratingTaste,
+  isSharingProfile,
+  onGenerateTaste,
+  onShareProfile,
+  tasteSections,
+  user,
+}: TasteSummaryCardProps) {
+  return (
+    <div className="relative overflow-hidden rounded-[3rem] border border-black/5 bg-white shadow-[0_30px_80px_-40px_rgba(0,0,0,0.35)]">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(168,85,247,0.18),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.12),_transparent_28%),linear-gradient(135deg,_rgba(250,250,250,0.96),_rgba(244,244,245,0.98))]" />
+      <div className="relative p-8 md:p-10 space-y-8">
+        <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3">
+            <span className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/80 px-4 py-2 text-[10px] font-black uppercase tracking-[0.3em] text-gray-500 backdrop-blur">
+              <Heart className="h-3.5 w-3.5 text-pink-500" fill="currentColor" />
+              Signature Taste
+            </span>
+            <div>
+              <h4 className="text-3xl md:text-4xl font-black tracking-tighter text-black">
+                {user?.username || 'Anonymous'}님의 취향 한 장 요약
+              </h4>
+              <p className="mt-2 text-sm md:text-base font-medium text-gray-500">
+                AI가 모아본 취향의 결, 좋아하는 무드, 다시 찾게 될 영감 포인트예요.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4">
+          {tasteSections.map((section, index) => (
+            <TasteSectionCard
+              key={`${section.title}-${index}`}
+              section={section}
+            />
+          ))}
+        </div>
+
+        <div className="rounded-[2rem] border border-dashed border-black/10 bg-white/70 p-5 text-sm font-medium leading-7 text-gray-600">
+          <span className="mr-2 inline-flex rounded-full bg-black px-3 py-1 text-[10px] font-black uppercase tracking-[0.25em] text-white">
+            Share Tip
+          </span>
+          공유 버튼을 누르면 프로필 문구를 먼저 클립보드에 복사한 뒤, 인스타그램으로 이동할 수 있게 도와드려요.
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-gray-200/80 pt-6">
+          <button
+            onClick={onGenerateTaste}
+            disabled={isGeneratingTaste}
+            className="flex items-center gap-2 rounded-2xl bg-white px-6 py-3 text-xs font-black uppercase tracking-widest text-black shadow-sm transition-all hover:bg-gray-100"
+          >
+            {isGeneratingTaste ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Sparkles className="w-4 h-4" />
+            )}
+            {isGeneratingTaste ? 'Analyzing...' : 'Re-Analyze'}
+          </button>
+          <button
+            onClick={onShareProfile}
+            disabled={isSharingProfile}
+            className="flex items-center gap-2 rounded-2xl bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 text-xs font-black uppercase tracking-widest text-white shadow-lg shadow-purple-500/30 transition-all hover:from-purple-700 hover:to-blue-700"
+          >
+            {isSharingProfile ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Instagram className="w-4 h-4" />
+            )}
+            {isSharingProfile ? 'Preparing...' : 'Share to IG'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyTasteState({
+  hasItems,
+  isGeneratingTaste,
+  onGenerateTaste,
+  onGoToFeed,
+}: EmptyTasteStateProps) {
+  return (
+    <div className="py-24 bg-gray-50 rounded-[3rem] flex flex-col items-center justify-center text-center space-y-8 px-4 border-2 border-dashed border-gray-200">
+      <div className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-sm">
+        <Sparkles className="w-8 h-8 text-yellow-400" fill="currentColor" />
+      </div>
+
+      {hasItems ? (
+        <div className="space-y-6 flex flex-col items-center">
+          <p className="text-gray-500 font-bold text-lg max-w-sm">
+            충분한 영감이 모였습니다.
+            <br />
+            당신의 무의식적인 패턴을 꺼내볼까요?
+          </p>
+          <button
+            onClick={onGenerateTaste}
+            disabled={isGeneratingTaste}
+            className="px-10 py-4 bg-black text-white rounded-full text-sm font-black tracking-widest uppercase hover:bg-gray-800 hover:scale-105 active:scale-95 transition-all flex items-center gap-3 disabled:opacity-50 shadow-xl"
+          >
+            {isGeneratingTaste ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Zap className="w-5 h-5 text-yellow-400" fill="currentColor" />
+            )}
+            {isGeneratingTaste ? 'Analyzing POSE...' : 'Analyze My POSE'}
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-6 flex flex-col items-center">
+          <p className="text-gray-400 font-bold text-lg">아직 수집된 영감이 없습니다.</p>
+          <button
+            type="button"
+            onClick={onGoToFeed}
+            className="px-8 py-3 bg-white border-2 border-gray-200 text-black rounded-full text-xs font-black uppercase tracking-widest hover:border-black transition-all"
+          >
+            Explore Feed
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getProfileImageUrl(item: SavedItem) {
+  if (item.image_url?.startsWith('http')) {
+    return item.image_url;
+  }
+  if (item.image_url) {
+    return `/api/images/${item.image_url}`;
+  }
+  return 'https://via.placeholder.com/400x500?text=No+Image';
+}
+
+function RecentInspirationsGrid({ items, onSelectItem }: RecentInspirationsGridProps) {
+  return (
+    <div className="space-y-8 pt-12">
+      <div className="flex items-center justify-between border-b border-black/5 pb-6">
+        <h4 className="text-xl font-black uppercase tracking-tighter text-black">
+          Recent Inspirations
+        </h4>
+        <div className="text-xs font-bold text-gray-400 uppercase tracking-widest bg-gray-100 px-3 py-1 rounded-full">
+          {items.length} Items
+        </div>
+      </div>
+      <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+        {items.slice(0, 12).map((item) => (
+          <div
+            key={item.id}
+            className="aspect-square bg-gray-100 overflow-hidden cursor-pointer group relative rounded-2xl"
+            onClick={() => onSelectItem(item)}
+          >
+            <img
+              src={getProfileImageUrl(item)}
+              className="w-full h-full object-cover grayscale opacity-80 group-hover:opacity-100 group-hover:grayscale-0 transition-all duration-500 group-hover:scale-110"
+              referrerPolicy="no-referrer"
+              onError={(e) => {
+                (e.target as HTMLImageElement).src =
+                  'https://via.placeholder.com/400x500?text=No+Image';
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export function ProfileTabContent({
   items,
@@ -105,7 +383,7 @@ export function ProfileTabContent({
 
   const handleGenerateTaste = async () => {
     setIsGeneratingTaste(true);
-    onTasteChange("");
+    onTasteChange('');
     try {
       const res = await fetch('/api/generate-taste', { method: 'POST' });
       const data = await res.json();
@@ -113,11 +391,11 @@ export function ProfileTabContent({
       if (data.success) {
         onTasteChange(data.summary);
       } else {
-        alert(data.message || "취향 분석에 실패했습니다.");
+        alert(data.message || '취향 분석에 실패했습니다.');
       }
     } catch (error) {
-      console.error("Taste generation failed:", error);
-      alert("취향 분석 중 에러가 발생했습니다.");
+      console.error('Taste generation failed:', error);
+      alert('취향 분석 중 에러가 발생했습니다.');
     } finally {
       setIsGeneratingTaste(false);
     }
@@ -159,7 +437,9 @@ export function ProfileTabContent({
           return;
         } catch (error) {
           if (error instanceof DOMException && error.name === 'AbortError') {
-            alert('공유가 취소되었어요. 복사된 텍스트를 인스타그램에 붙여넣어 공유할 수 있어요.');
+            alert(
+              '공유가 취소되었어요. 복사된 텍스트를 인스타그램에 붙여넣어 공유할 수 있어요.',
+            );
             return;
           }
           console.error('Native share failed, falling back to Instagram helper:', error);
@@ -184,183 +464,35 @@ export function ProfileTabContent({
       exit={{ opacity: 0, y: -20 }}
       className="max-w-4xl mx-auto space-y-16 py-8"
     >
-      <div className="flex flex-col md:flex-row items-start md:items-end justify-between gap-8 border-b border-black/10 pb-12">
-        <div className="space-y-5">
-          <div className="w-28 h-28 rounded-full bg-gradient-to-tr from-blue-600 via-yellow-300 to-purple-600 p-[3px] shadow-2xl">
-            <div className="w-full h-full bg-white rounded-full flex items-center justify-center overflow-hidden">
-              <User className="w-12 h-12 text-black" />
-            </div>
-          </div>
-          <div className="space-y-1">
-            <h2 className="text-5xl font-black tracking-tighter text-black uppercase">
-              {user?.username || 'Anonymous'}
-            </h2>
-            <p className="text-xs font-black text-gray-400 uppercase tracking-widest bg-gray-100 inline-block px-3 py-1 rounded-full">
-              POSE Creator No. {user?.id || '000'}
-            </p>
-          </div>
-        </div>
-        <div className="text-left md:text-right max-w-xs">
-          <p className="text-2xl font-black text-black leading-tight tracking-tighter uppercase bg-clip-text text-transparent bg-gradient-to-r from-black to-gray-500">
-            "My Vibe is<br/>my POSE."
-          </p>
-        </div>
-      </div>
+      <ProfileHeader user={user} />
 
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-12">
-        <div className="lg:col-span-4 space-y-6">
-          <div className="flex items-center gap-3 text-[10px] font-black uppercase tracking-[0.3em] text-blue-600">
-            <Zap className="w-3.5 h-3.5" fill="currentColor" />
-            Taste Analysis
-          </div>
-          <h3 className="text-3xl font-black tracking-tighter leading-none uppercase">
-            The Patterns<br/>of your<br/>Choices.
-          </h3>
-          <div className="h-2 w-12 bg-black rounded-full" />
-        </div>
+      <div className="flex gap-10 flex-col">
+        <TasteAnalysisHeader user={user} />
 
         <div className="lg:col-span-8">
-          {taste ? (
-            <div className="relative overflow-hidden rounded-[3rem] border border-black/5 bg-white shadow-[0_30px_80px_-40px_rgba(0,0,0,0.35)]">
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(168,85,247,0.18),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.12),_transparent_28%),linear-gradient(135deg,_rgba(250,250,250,0.96),_rgba(244,244,245,0.98))]" />
-              <div className="relative p-8 md:p-10 space-y-8">
-                <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
-                  <div className="space-y-3">
-                    <span className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/80 px-4 py-2 text-[10px] font-black uppercase tracking-[0.3em] text-gray-500 backdrop-blur">
-                      <Heart className="h-3.5 w-3.5 text-pink-500" fill="currentColor" />
-                      Signature Taste
-                    </span>
-                    <div>
-                      <h4 className="text-3xl md:text-4xl font-black tracking-tighter text-black">
-                        {user?.username || 'Anonymous'}님의 취향 한 장 요약
-                      </h4>
-                      <p className="mt-2 text-sm md:text-base font-medium text-gray-500">
-                        AI가 모아본 취향의 결, 좋아하는 무드, 다시 찾게 될 영감 포인트예요.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="rounded-[2rem] bg-black px-5 py-4 text-white shadow-xl shadow-black/10">
-                    <p className="text-[10px] font-black uppercase tracking-[0.25em] text-white/60">Pose Index</p>
-                    <p className="mt-2 text-3xl font-black tracking-tight">{Math.max(items.length, tasteSections.length).toString().padStart(2, '0')}</p>
-                    <p className="mt-1 text-xs font-medium text-white/70">Collected inspirations analyzed</p>
-                  </div>
-                </div>
-
-                <div className="grid gap-4 md:grid-cols-2">
-                  {tasteSections.map((section, index) => (
-                    <div
-                      key={`${section.title}-${index}`}
-                      className={`rounded-[2rem] border bg-gradient-to-br ${section.accent} p-6 backdrop-blur-sm`}
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-gray-400">Taste Cue {String(index + 1).padStart(2, '0')}</p>
-                          <h5 className="mt-2 text-xl font-black tracking-tight text-black capitalize">{section.title}</h5>
-                        </div>
-                        <Compass className="h-5 w-5 text-gray-400" />
-                      </div>
-                      <div className="mt-5 space-y-3">
-                        {section.body.map((line, lineIndex) => (
-                          <div key={`${section.title}-${lineIndex}`} className="flex gap-3 rounded-2xl bg-white/80 px-4 py-3 shadow-sm shadow-black/5">
-                            <div className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-black" />
-                            <p className="text-sm font-medium leading-6 text-gray-700">{line}</p>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-
-                <div className="rounded-[2rem] border border-dashed border-black/10 bg-white/70 p-5 text-sm font-medium leading-7 text-gray-600">
-                  <span className="mr-2 inline-flex rounded-full bg-black px-3 py-1 text-[10px] font-black uppercase tracking-[0.25em] text-white">Share Tip</span>
-                  공유 버튼을 누르면 프로필 문구를 먼저 클립보드에 복사한 뒤, 인스타그램으로 이동할 수 있게 도와드려요.
-                </div>
-
-                <div className="flex flex-wrap items-center justify-end gap-3 border-t border-gray-200/80 pt-6">
-                  <button
-                    onClick={handleGenerateTaste}
-                    disabled={isGeneratingTaste}
-                    className="flex items-center gap-2 rounded-2xl bg-white px-6 py-3 text-xs font-black uppercase tracking-widest text-black shadow-sm transition-all hover:bg-gray-100"
-                  >
-                    {isGeneratingTaste ? <Loader2 className="w-4 h-4 animate-spin" /> : <Sparkles className="w-4 h-4" />}
-                    {isGeneratingTaste ? 'Analyzing...' : 'Re-Analyze'}
-                  </button>
-                  <button
-                    onClick={handleShareProfile}
-                    disabled={isSharingProfile}
-                    className="flex items-center gap-2 rounded-2xl bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 text-xs font-black uppercase tracking-widest text-white shadow-lg shadow-purple-500/30 transition-all hover:from-purple-700 hover:to-blue-700"
-                  >
-                    {isSharingProfile ? <Loader2 className="w-4 h-4 animate-spin" /> : <Instagram className="w-4 h-4" />}
-                    {isSharingProfile ? 'Preparing...' : 'Share to IG'}
-                  </button>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="py-24 bg-gray-50 rounded-[3rem] flex flex-col items-center justify-center text-center space-y-8 px-4 border-2 border-dashed border-gray-200">
-              <div className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-sm">
-                <Sparkles className="w-8 h-8 text-yellow-400" fill="currentColor" />
-              </div>
-
-              {items.length > 0 ? (
-                <div className="space-y-6 flex flex-col items-center">
-                  <p className="text-gray-500 font-bold text-lg max-w-sm">
-                    충분한 영감이 모였습니다.<br />당신의 무의식적인 패턴을 꺼내볼까요?
-                  </p>
-                  <button
-                    onClick={handleGenerateTaste}
-                    disabled={isGeneratingTaste}
-                    className="px-10 py-4 bg-black text-white rounded-full text-sm font-black tracking-widest uppercase hover:bg-gray-800 hover:scale-105 active:scale-95 transition-all flex items-center gap-3 disabled:opacity-50 shadow-xl"
-                  >
-                    {isGeneratingTaste ? <Loader2 className="w-5 h-5 animate-spin" /> : <Zap className="w-5 h-5 text-yellow-400" fill="currentColor" />}
-                    {isGeneratingTaste ? 'Analyzing POSE...' : 'Analyze My POSE'}
-                  </button>
-                </div>
-              ) : (
-                <div className="space-y-6 flex flex-col items-center">
-                  <p className="text-gray-400 font-bold text-lg">아직 수집된 영감이 없습니다.</p>
-                  <button
-                    type="button"
-                    onClick={onGoToFeed}
-                    className="px-8 py-3 bg-white border-2 border-gray-200 text-black rounded-full text-xs font-black uppercase tracking-widest hover:border-black transition-all"
-                  >
-                    Explore Feed
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="space-y-8 pt-12">
-        <div className="flex items-center justify-between border-b border-black/5 pb-6">
-          <h4 className="text-xl font-black uppercase tracking-tighter text-black">
-            Recent Inspirations
-          </h4>
-          <div className="text-xs font-bold text-gray-400 uppercase tracking-widest bg-gray-100 px-3 py-1 rounded-full">
-            {items.length} Items
-          </div>
-        </div>
-        <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
-          {items.slice(0, 12).map((item) => (
-            <div
-              key={item.id}
-              className="aspect-square bg-gray-100 overflow-hidden cursor-pointer group relative rounded-2xl"
-              onClick={() => onSelectItem(item)}
-            >
-              <img
-                src={item.image_url?.startsWith('http') ? item.image_url : item.image_url ? `/api/images/${item.image_url}` : 'https://via.placeholder.com/400x500?text=No+Image'}
-                className="w-full h-full object-cover grayscale opacity-80 group-hover:opacity-100 group-hover:grayscale-0 transition-all duration-500 group-hover:scale-110"
-                referrerPolicy="no-referrer"
-                onError={(e) => {
-                  (e.target as HTMLImageElement).src = 'https://via.placeholder.com/400x500?text=No+Image';
-                }}
+          {taste
+            ? (
+              <TasteSummaryCard
+                isGeneratingTaste={isGeneratingTaste}
+                isSharingProfile={isSharingProfile}
+                onGenerateTaste={handleGenerateTaste}
+                onShareProfile={handleShareProfile}
+                tasteSections={tasteSections}
+                user={user}
               />
-            </div>
-          ))}
+            )
+            : (
+              <EmptyTasteState
+                hasItems={items.length > 0}
+                isGeneratingTaste={isGeneratingTaste}
+                onGenerateTaste={handleGenerateTaste}
+                onGoToFeed={onGoToFeed}
+              />
+            )}
         </div>
       </div>
+
+      <RecentInspirationsGrid items={items} onSelectItem={onSelectItem} />
     </motion.div>
   );
 }

--- a/project/frontend/src/components/ProfileTabContent.tsx
+++ b/project/frontend/src/components/ProfileTabContent.tsx
@@ -11,6 +11,11 @@ type TasteProfileSection = {
   accent: string;
 };
 
+type TasteBodyParagraph = {
+  description: string;
+  title?: string;
+};
+
 type ProfileTabContentProps = {
   items: SavedItem[];
   onGoToFeed: () => void;
@@ -72,9 +77,100 @@ function normalizeTasteValue(value: unknown): string[] {
     });
   }
   return String(value)
-    .split(/\n+/)
-    .map((line) => line.trim())
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
     .filter(Boolean);
+}
+
+function cleanTasteParagraph(text: string) {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+function cleanTasteHeading(text: string) {
+  return text.replace(/^\*+/, '').replace(/\*+$/, '').trim();
+}
+
+function parseTasteBodyParagraphs(body: string[]): TasteBodyParagraph[] {
+  const rawText = body.join('\n\n').trim();
+  if (!rawText) return [];
+
+  const headingRegex = /\*+[^*]+?\*+/g;
+  const headingMatches = Array.from(rawText.matchAll(headingRegex));
+
+  if (headingMatches.length > 0) {
+    const paragraphs = headingMatches
+      .map((match, index) => {
+        const matchText = match[0] ?? '';
+        const title = cleanTasteHeading(matchText);
+        const start = (match.index ?? 0) + matchText.length;
+        const end = index < headingMatches.length - 1
+          ? (headingMatches[index + 1].index ?? rawText.length)
+          : rawText.length;
+        const description = cleanTasteParagraph(rawText.slice(start, end));
+
+        return {
+          title: title || undefined,
+          description,
+        };
+      })
+      .filter((paragraph) => paragraph.title || paragraph.description);
+
+    if (paragraphs.length > 0) {
+      return paragraphs;
+    }
+  }
+
+  const lines = rawText
+    .split('\n')
+    .map((line) => line.trim());
+  const starredHeadingRegex = /^\*+\s*(.+?)\s*\*+$/;
+  const paragraphs: TasteBodyParagraph[] = [];
+  let currentTitle: string | undefined;
+  let currentLines: string[] = [];
+
+  const flushParagraph = () => {
+    const description = cleanTasteParagraph(currentLines.join('\n'));
+    if (!currentTitle && !description) return;
+
+    paragraphs.push({
+      title: currentTitle,
+      description,
+    });
+
+    currentTitle = undefined;
+    currentLines = [];
+  };
+
+  lines.forEach((line) => {
+    if (!line) {
+      return;
+    }
+
+    const headingMatch = line.match(starredHeadingRegex);
+    if (headingMatch) {
+      flushParagraph();
+      currentTitle = headingMatch[1].trim();
+      currentLines = [];
+      return;
+    }
+
+    currentLines.push(line);
+  });
+
+  flushParagraph();
+
+  if (paragraphs.length > 0) {
+    return paragraphs;
+  }
+
+  return body
+    .map((entry) => cleanTasteParagraph(entry))
+    .filter(Boolean)
+    .map((description) => ({ description }));
 }
 
 function buildTasteProfileSections(taste: string): TasteProfileSection[] {
@@ -111,8 +207,9 @@ function buildTasteProfileSections(taste: string): TasteProfileSection[] {
       const title = headingMatch ? headingMatch[1] : `Taste Point ${index + 1}`;
       const contentSource = headingMatch ? rest : lines;
       const body = contentSource
-        .flatMap((line) => line.split(/(?<=\.)\s+|•\s+|^-\s+/))
-        .map((line) => line.replace(/^[-*]\s*/, '').trim())
+        .join('\n')
+        .split(/\n{2,}/)
+        .map((paragraph) => cleanTasteParagraph(paragraph))
         .filter(Boolean);
       return {
         title,
@@ -176,6 +273,8 @@ function TasteAnalysisHeader(_: TasteAnalysisHeaderProps) {
 }
 
 function TasteSectionCard({ section }: TasteSectionCardProps) {
+  const paragraphs = parseTasteBodyParagraphs(section.body);
+
   return (
     <div className={`rounded-[2rem] border bg-gradient-to-br ${section.accent} p-6 backdrop-blur-sm`}>
       <div className="flex items-start justify-between gap-3">
@@ -187,13 +286,19 @@ function TasteSectionCard({ section }: TasteSectionCardProps) {
         <Compass className="h-5 w-5 text-gray-400" />
       </div>
       <div className="mt-5 space-y-3">
-        {section.body.map((line, lineIndex) => (
+        {paragraphs.map((paragraph, lineIndex) => (
           <div
             key={`${section.title}-${lineIndex}`}
-            className="flex gap-3 rounded-2xl bg-white/80 px-4 py-3 shadow-sm shadow-black/5"
+            className="rounded-2xl bg-white/80 px-4 py-4 shadow-sm shadow-black/5"
           >
-            <div className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-black" />
-            <p className="text-sm font-medium leading-6 text-gray-700">{line}</p>
+            {paragraph.title ? (
+              <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
+                {paragraph.title}
+              </p>
+            ) : null}
+            <p className="mt-2 text-sm font-medium leading-6 text-gray-700">
+              {paragraph.description}
+            </p>
           </div>
         ))}
       </div>

--- a/project/frontend/src/components/ProfileTabContent.tsx
+++ b/project/frontend/src/components/ProfileTabContent.tsx
@@ -59,10 +59,10 @@ type RecentInspirationsGridProps = {
 };
 
 const tasteSectionAccents = [
-  'from-purple-500/15 via-pink-500/10 to-transparent border-purple-200/70',
-  'from-blue-500/15 via-cyan-500/10 to-transparent border-blue-200/70',
-  'from-yellow-400/20 via-orange-400/10 to-transparent border-yellow-200/70',
-  'from-emerald-500/15 via-teal-500/10 to-transparent border-emerald-200/70',
+  'from-sky-500/8 via-blue-500/4 to-transparent border-sky-100',
+  'from-blue-500/8 via-cyan-500/4 to-transparent border-blue-100',
+  'from-indigo-500/8 via-sky-500/4 to-transparent border-indigo-100',
+  'from-cyan-500/8 via-teal-500/4 to-transparent border-cyan-100',
 ];
 
 function normalizeTasteValue(value: unknown): string[] {
@@ -253,27 +253,19 @@ function ProfileHeader({ user }: ProfileHeaderProps) {
   );
 }
 
-function TasteAnalysisHeader(_: TasteAnalysisHeaderProps) {
-  return (
-    <div className="lg:col-span-4 space-y-6">
-      <div className="flex items-center gap-3 text-[10px] font-black uppercase tracking-[0.3em] text-blue-600">
-        <Zap className="w-3.5 h-3.5" fill="currentColor" />
-        Taste Analysis
-      </div>
-      <h3 className="text-3xl font-black tracking-tighter leading-none uppercase">
-        The Patterns
-        <br />
-        of your
-        <br />
-        Choices.
-      </h3>
-      <div className="h-2 w-12 bg-black rounded-full" />
-    </div>
-  );
-}
 
 function TasteSectionCard({ section }: TasteSectionCardProps) {
   const paragraphs = parseTasteBodyParagraphs(section.body);
+  const [openParagraphs, setOpenParagraphs] = useState<Record<number, boolean>>(
+    Object.fromEntries(paragraphs.map((_, index) => [index, true])),
+  );
+
+  const toggleParagraph = (index: number) => {
+    setOpenParagraphs((current) => ({
+      ...current,
+      [index]: !current[index],
+    }));
+  };
 
   return (
     <div className={`rounded-[2rem] border bg-gradient-to-br ${section.accent} p-6 backdrop-blur-sm`}>
@@ -283,22 +275,28 @@ function TasteSectionCard({ section }: TasteSectionCardProps) {
             {section.title}
           </h5>
         </div>
-        <Compass className="h-5 w-5 text-gray-400" />
+        <Compass className="h-5 w-5 text-blue-200" />
       </div>
       <div className="mt-5 space-y-3">
         {paragraphs.map((paragraph, lineIndex) => (
           <div
             key={`${section.title}-${lineIndex}`}
-            className="rounded-2xl bg-white/80 px-4 py-4 shadow-sm shadow-black/5"
+            className="rounded-2xl border border-slate-100 bg-white px-4 py-4 shadow-sm shadow-slate-950/5"
           >
             {paragraph.title ? (
-              <p className="text-xs font-black uppercase tracking-[0.2em] text-gray-500">
-                {paragraph.title}
+              <button
+                type="button"
+                onClick={() => toggleParagraph(lineIndex)}
+                className="inline-flex items-center rounded-full bg-gradient-to-r from-sky-100 via-blue-100 to-cyan-100 px-4 py-1.5 text-xs font-black uppercase tracking-[0.18em] text-blue-600 transition-all hover:brightness-95"
+              >
+                #{paragraph.title}
+              </button>
+            ) : null}
+            {openParagraphs[lineIndex] !== false ? (
+              <p className="mt-3 text-sm font-medium leading-6 text-gray-700">
+                {paragraph.description}
               </p>
             ) : null}
-            <p className="mt-2 text-sm font-medium leading-6 text-gray-700">
-              {paragraph.description}
-            </p>
           </div>
         ))}
       </div>
@@ -315,20 +313,22 @@ function TasteSummaryCard({
   user,
 }: TasteSummaryCardProps) {
   return (
-    <div className="relative overflow-hidden rounded-[3rem] border border-black/5 bg-white shadow-[0_30px_80px_-40px_rgba(0,0,0,0.35)]">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(168,85,247,0.18),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.12),_transparent_28%),linear-gradient(135deg,_rgba(250,250,250,0.96),_rgba(244,244,245,0.98))]" />
+    <div className="relative overflow-hidden rounded-[3rem] border border-slate-100 bg-white shadow-[0_30px_80px_-40px_rgba(15,23,42,0.14)]">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.08),_transparent_26%),radial-gradient(circle_at_top_right,_rgba(59,130,246,0.07),_transparent_24%),linear-gradient(180deg,_rgba(255,255,255,0.99),_rgba(248,250,252,0.98))]" />
       <div className="relative p-8 md:p-10 space-y-8">
         <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
           <div className="space-y-3">
-            <span className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/80 px-4 py-2 text-[10px] font-black uppercase tracking-[0.3em] text-gray-500 backdrop-blur">
-              <Heart className="h-3.5 w-3.5 text-pink-500" fill="currentColor" />
-              Signature Taste
+            <span className="inline-flex items-center gap-2 rounded-full border border-sky-100 bg-white px-4 py-2 text-[10px] font-black uppercase tracking-[0.3em] text-blue-600">
+              <div className="flex items-center gap-3 text-[10px] font-black uppercase tracking-[0.3em] text-blue-600">
+                <Zap className="w-3.5 h-3.5" fill="currentColor" />
+                Taste Analysis
+              </div>
             </span>
             <div>
               <h4 className="text-3xl md:text-4xl font-black tracking-tighter text-black">
                 {user?.username || 'Anonymous'}님의 취향 한 장 요약
               </h4>
-              <p className="mt-2 text-sm md:text-base font-medium text-gray-500">
+              <p className="mt-2 text-sm md:text-base font-medium text-slate-500">
                 AI가 모아본 취향의 결, 좋아하는 무드, 다시 찾게 될 영감 포인트예요.
               </p>
             </div>
@@ -344,30 +344,30 @@ function TasteSummaryCard({
           ))}
         </div>
 
-        <div className="rounded-[2rem] border border-dashed border-black/10 bg-white/70 p-5 text-sm font-medium leading-7 text-gray-600">
-          <span className="mr-2 inline-flex rounded-full bg-black px-3 py-1 text-[10px] font-black uppercase tracking-[0.25em] text-white">
+        <div className="rounded-[2rem] border border-dashed border-sky-100 bg-white p-5 text-sm font-medium leading-7 text-slate-600">
+          <span className="mr-2 inline-flex rounded-full bg-sky-500 px-3 py-1 text-[10px] font-black uppercase tracking-[0.25em] text-white">
             Share Tip
           </span>
           공유 버튼을 누르면 프로필 문구를 먼저 클립보드에 복사한 뒤, 인스타그램으로 이동할 수 있게 도와드려요.
         </div>
 
-        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-gray-200/80 pt-6">
+        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-slate-100 pt-6">
           <button
             onClick={onGenerateTaste}
             disabled={isGeneratingTaste}
-            className="flex items-center gap-2 rounded-2xl bg-white px-6 py-3 text-xs font-black uppercase tracking-widest text-black shadow-sm transition-all hover:bg-gray-100"
+            className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-6 py-3 text-xs font-black uppercase tracking-widest text-slate-900 shadow-sm transition-all hover:bg-slate-50"
           >
             {isGeneratingTaste ? (
               <Loader2 className="w-4 h-4 animate-spin" />
             ) : (
-              <Sparkles className="w-4 h-4" />
+              <Sparkles className="w-4 h-4 text-blue-500" />
             )}
             {isGeneratingTaste ? 'Analyzing...' : 'Re-Analyze'}
           </button>
           <button
             onClick={onShareProfile}
             disabled={isSharingProfile}
-            className="flex items-center gap-2 rounded-2xl bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 text-xs font-black uppercase tracking-widest text-white shadow-lg shadow-purple-500/30 transition-all hover:from-purple-700 hover:to-blue-700"
+            className="flex items-center gap-2 rounded-2xl bg-gradient-to-r from-sky-500 to-blue-600 px-6 py-3 text-xs font-black uppercase tracking-widest text-white shadow-lg shadow-blue-500/20 transition-all hover:from-sky-600 hover:to-blue-700"
           >
             {isSharingProfile ? (
               <Loader2 className="w-4 h-4 animate-spin" />
@@ -572,8 +572,6 @@ export function ProfileTabContent({
       <ProfileHeader user={user} />
 
       <div className="flex gap-10 flex-col">
-        <TasteAnalysisHeader user={user} />
-
         <div className="lg:col-span-8">
           {taste
             ? (

--- a/project/frontend/src/components/SearchResultCard.tsx
+++ b/project/frontend/src/components/SearchResultCard.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 
+import { getItemTitle } from '../lib/itemFacts';
 import type { SavedItem } from '../types/item';
 
 type SearchResultCardProps = {
@@ -15,8 +16,7 @@ export function SearchResultCard({
   onClick,
   onSave,
 }: SearchResultCardProps) {
-  const factsObj = typeof item.facts === 'string' ? JSON.parse(item.facts) : item.facts;
-  const title = factsObj?.title || item.summary_text || '제목 없음';
+  const title = getItemTitle(item);
 
   return (
     <motion.div

--- a/project/frontend/src/lib/itemFacts.ts
+++ b/project/frontend/src/lib/itemFacts.ts
@@ -1,0 +1,27 @@
+import type { SavedItem } from '../types/item';
+
+type ParsedFacts = Record<string, unknown> | null;
+
+export function parseItemFacts(item: SavedItem): ParsedFacts {
+  if (!item.facts) return null;
+
+  if (typeof item.facts === 'string') {
+    try {
+      const parsed = JSON.parse(item.facts);
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return item.facts;
+}
+
+export function getItemTitle(item: SavedItem): string {
+  const facts = parseItemFacts(item);
+  const lowerTitle = typeof facts?.title === 'string' ? facts.title : undefined;
+  const upperTitle = typeof facts?.Title === 'string' ? facts.Title : undefined;
+  const title = lowerTitle || upperTitle;
+
+  return title || item.summary_text || item.recommend || '제목 없음';
+}


### PR DESCRIPTION
## 변경 내용
- 공용 `facts` 파서와 title 헬퍼를 재사용하도록 정리해서, 피드 카드와 검색 결과, 상세 다이얼로그가 모두 `facts.title` 기준으로 일관되게 제목을 표시하도록 변경했습니다.
- `FeedItemCard`가 `recommend` 대신 파싱된 title을 보여주도록 수정했습니다.
- 피드 레이아웃을 masonry `columns` 방식에서 일정한 `grid` 방식으로 바꿔 카드 크기가 균일하게 보이도록 정리했습니다.
- 피드 카드의 이미지 높이와 카드 간 간격을 조금 줄였고, 하단 facts 패널에서는 중복되는 `title`을 제거했습니다.

## 변경 이유
- 제목 파싱 로직이 여러 컴포넌트에 흩어져 있어서 표시 방식이 일관되지 않았습니다.
- 피드 카드는 레이아웃과 내부 높이 차이 때문에 카드 크기가 들쭉날쭉해 보일 수 있었습니다.
- 카드 상단에 이미 제목이 보이는데 하단 facts 패널에서 같은 정보가 반복되고 있었습니다.

## 영향
- 저장된 피드 아이템이 추출된 `facts.title` 기준으로 더 자연스럽게 표시됩니다.
- 피드 카드가 더 균일하고 컴팩트하게 보입니다.
- 중복된 제목 표시가 사라져 피드를 더 빠르게 훑어볼 수 있습니다.

## 검증
- `./node_modules/.bin/tsc --noEmit -p src/tsconfig.json`

fixed #27 