### PR TITLE
Improve Instagram crawler resilience: semantic selectors, srcset handling, stealth, and streaming downloads

### DIFF
--- a/project/backend/Step1/instagram_crawler.py
+++ b/project/backend/Step1/instagram_crawler.py
@@ -4,26 +4,97 @@ import os
 import uuid
 import asyncio
 import random
+import mimetypes
+from urllib.parse import urlparse
+
 import httpx
-from typing import Dict
+from typing import Dict, List, Optional
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+from playwright_stealth import stealth_async
 
 logger = logging.getLogger(__name__)
 
-# --- 정규식 및 선택자 ---
 HASHTAG_PATTERN = re.compile(r"(?<!\w)#([^\s#.,!?;:]+)")
 VIDEO_SELECTOR = "video"
-NEXT_BUTTON_SELECTOR = "button[aria-label*='Next'], button[aria-label*='다음'], div[role='button'] svg[aria-label='다음']"
+NEXT_BUTTON_SELECTOR = "button[aria-label*='Next'], button[aria-label*='다음']"
 
-CAPTION_CANDIDATES = [
-    "h1",
-    "div._a9zs", 
-    "span[dir='auto']",
-    "span._ap3a",
-]
+CAPTION_CONTAINER_SELECTOR = "article ul li"
 
-async def human_delay(min_sec: float = 0.8, max_sec: float = 2.0):
-    await asyncio.sleep(random.uniform(min_sec, max_sec))
+
+class InstagramAccountPool:
+    """간단한 세션/쿠키 로테이션 풀."""
+
+    def __init__(self, accounts: Optional[List[Dict[str, object]]] = None, cooldown_sec: int = 900):
+        self.accounts = accounts or []
+        self.cooldown_sec = cooldown_sec
+
+    def get_available_account(self) -> Optional[Dict[str, object]]:
+        now = asyncio.get_event_loop().time()
+        for account in self.accounts:
+            blocked_until = account.get("blocked_until", 0)
+            if blocked_until <= now:
+                return account
+        return None
+
+    def mark_temporary_block(self, account_id: str):
+        now = asyncio.get_event_loop().time()
+        for account in self.accounts:
+            if account.get("id") == account_id:
+                account["blocked_until"] = now + self.cooldown_sec
+                break
+
+
+async def human_delay(mu: float = 1.8, sigma: float = 0.9, min_sec: float = 0.3, max_sec: float = 5.0):
+    delay = max(min_sec, min(max_sec, random.gauss(mu, sigma)))
+    await asyncio.sleep(delay)
+
+
+async def apply_stealth(page):
+    await stealth_async(page)
+    await page.add_init_script(
+        """
+        Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+        """
+    )
+
+
+def _extract_highest_resolution_srcset(srcset: str) -> Optional[str]:
+    candidates = []
+    for entry in srcset.split(","):
+        parts = entry.strip().split()
+        if not parts:
+            continue
+        url = parts[0]
+        size = 0
+        if len(parts) > 1 and parts[1].endswith("w"):
+            try:
+                size = int(parts[1][:-1])
+            except ValueError:
+                size = 0
+        candidates.append((size, url))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return candidates[0][1]
+
+
+async def _extract_caption_from_dom(post_container) -> str:
+    caption_items = post_container.locator(CAPTION_CONTAINER_SELECTOR)
+    count = await caption_items.count()
+    if count == 0:
+        return ""
+
+    first_li = caption_items.nth(0)
+    text_blocks = first_li.locator("span[dir='auto']")
+    texts = []
+    for i in range(await text_blocks.count()):
+        text = (await text_blocks.nth(i).inner_text()).strip()
+        if text and not text.startswith("@"):
+            texts.append(text)
+
+    return "\n".join(texts).strip()
+
 
 async def crawl_instagram_post(page, post_url: str, max_slides: int = 10) -> Dict[str, object]:
     result = {
@@ -35,19 +106,34 @@ async def crawl_instagram_post(page, post_url: str, max_slides: int = 10) -> Dic
         "error": None,
         "blocked": False,
         "requires_login": False,
+        "graphql_payloads": [],
     }
 
     try:
-        # 페이지 이동 및 로드 대기
-        await human_delay(0.5, 1.5)
+        await apply_stealth(page)
+
+        network_payloads = []
+
+        async def handle_response(resp):
+            ctype = (resp.headers.get("content-type") or "").lower()
+            if "json" not in ctype:
+                return
+            if "graphql" in resp.url or "/api/v1/" in resp.url:
+                try:
+                    payload = await resp.json()
+                    network_payloads.append({"url": resp.url, "payload": payload})
+                except Exception:
+                    return
+
+        page.on("response", handle_response)
+
+        await human_delay()
         await page.goto(post_url, wait_until="domcontentloaded")
-        
+
         try:
-            # article이나 main 태그가 뜰 때까지 대기
             await page.wait_for_selector("article, main", timeout=15000)
         except PlaywrightTimeoutError:
-            page_text = await page.content()
-            page_text = page_text.lower()
+            page_text = (await page.content()).lower()
             if "login" in page.url or "로그인" in page_text:
                 result["requires_login"] = True
                 result["error"] = "로그인이 필요하거나 쿠키가 만료되었습니다."
@@ -56,66 +142,58 @@ async def crawl_instagram_post(page, post_url: str, max_slides: int = 10) -> Dic
                 result["error"] = "접근이 차단되었거나 페이지 구조가 변경되었습니다."
             return result
 
-        # 컨테이너 설정
-        if await page.locator("article").count() > 0:
-            post_container = page.locator("article").first
-        else:
-            post_container = page.locator("main").first
+        post_container = page.locator("article").first if await page.locator("article").count() > 0 else page.locator("main").first
 
-        # 1. 본문(Caption) 및 해시태그 추출
-        for selector in CAPTION_CANDIDATES:
-            elements = await post_container.locator(selector).all()
-            for element in elements:
-                if await element.is_visible():
-                    text = await element.inner_text()
-                    text = text.strip()
-                    # 아이디가 아닌 '진짜 본문(15자 이상)'인지 검증
-                    if text and not text.startswith("#") and len(text) > 15:
-                        result["caption"] = text
-                        result["hashtags"] = HASHTAG_PATTERN.findall(text)
-                        break
-            if result["caption"]:
-                break
+        caption = await _extract_caption_from_dom(post_container)
+        if caption:
+            result["caption"] = caption
+            result["hashtags"] = HASHTAG_PATTERN.findall(caption)
 
-        # 2. 미디어(이미지/비디오) 추출
         all_images = []
         is_video = False
 
         for _ in range(max_slides):
-            # 화면이 로드되고 슬라이드가 넘어갈 시간을 잠깐 줌
             await page.wait_for_timeout(500)
-            await human_delay(1.2, 2.5)
-            # 비디오 여부 체크
+            await human_delay()
+
             if await post_container.locator(VIDEO_SELECTOR).count() > 0:
                 is_video = True
-            
+
             images = await post_container.locator("img").evaluate_all(
                 """elements => elements
-                    .filter(e => e.closest('a') === null)
                     .filter(e => e.clientWidth > 250)
-                    .map(e => e.src)
+                    .map(e => {
+                        const srcset = e.getAttribute('srcset') || '';
+                        return { src: e.src, srcset };
+                    })
                 """
             )
-            
-            for src in images:
-                if not src: continue
-                if "cdninstagram.com" in src or "fbcdn.net" in src:
-                    all_images.append(src)
 
-            # 다음 슬라이드 버튼 찾기 및 클릭
+            for image in images:
+                best = _extract_highest_resolution_srcset(image.get("srcset", "")) or image.get("src")
+                if best and ("cdninstagram.com" in best or "fbcdn.net" in best):
+                    all_images.append(best)
+
             next_btn = post_container.locator(NEXT_BUTTON_SELECTOR).first
             if await next_btn.is_visible():
-                await next_btn.hover()
-                await human_delay(0.2, 0.6)
-                await next_btn.click()
-                await page.wait_for_timeout(1000) # 슬라이드 애니메이션 대기
+                box = await next_btn.bounding_box()
+                if box:
+                    x = box["x"] + box["width"] / 2
+                    y = box["y"] + box["height"] / 2
+                    await page.mouse.move(x + random.uniform(-5, 5), y + random.uniform(-3, 3), steps=10)
+                    await human_delay(mu=0.4, sigma=0.2, min_sec=0.1, max_sec=1.2)
+                    await page.mouse.down()
+                    await human_delay(mu=0.25, sigma=0.1, min_sec=0.08, max_sec=0.8)
+                    await page.mouse.up()
+                else:
+                    await next_btn.click()
+                await page.wait_for_timeout(1000)
             else:
                 break
 
-        # 중복된 이미지 URL 제거 (순서는 그대로 유지)
         result["image_urls"] = list(dict.fromkeys(all_images))
+        result["graphql_payloads"] = network_payloads
 
-        # 게시물 타입 판별
         if is_video:
             result["post_type"] = "video"
         elif len(result["image_urls"]) > 1:
@@ -127,45 +205,54 @@ async def crawl_instagram_post(page, post_url: str, max_slides: int = 10) -> Dic
 
     return result
 
+
 FAKE_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
     "Referer": "https://www.instagram.com/",
     "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
 }
 
-# 단일 이미지 다운로드용 헬퍼 함수 (Non-blocking 파일 저장)
-async def _download_single_image(client: httpx.AsyncClient, url: str, save_dir: str) -> str:
+
+def _extension_from_content_type(content_type: str) -> str:
+    mime = content_type.split(";")[0].strip().lower()
+    ext = mimetypes.guess_extension(mime) or ""
+    if ext in {".jpe", ".jpeg"}:
+        return ".jpg"
+    return ext or ".bin"
+
+
+async def _download_single_image(client: httpx.AsyncClient, url: str, save_dir: str) -> Optional[str]:
     try:
-        response = await client.get(url, timeout=10.0)
-        response.raise_for_status()
+        async with client.stream("GET", url, timeout=20.0) as response:
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "application/octet-stream")
+            ext = _extension_from_content_type(content_type)
 
-        # 고유한 UUID 파일명 생성 (여러 요청이 겹쳐도 덮어쓰기 방지)
-        file_name = f"{uuid.uuid4().hex}.jpg"
-        file_path = os.path.join(save_dir, file_name)
+            if ext == ".bin":
+                path_ext = os.path.splitext(urlparse(url).path)[1]
+                ext = path_ext if path_ext else ".bin"
 
-        # 파일 저장은 디스크 I/O이므로 서버 멈춤을 막기 위해 스레드 풀에서 실행
-        def save_file():
+            file_name = f"{uuid.uuid4().hex}{ext}"
+            file_path = os.path.join(save_dir, file_name)
+
             with open(file_path, "wb") as f:
-                f.write(response.content)
-                
-        await asyncio.to_thread(save_file)
+                async for chunk in response.aiter_bytes(chunk_size=1024 * 64):
+                    f.write(chunk)
+
         return file_path
     except Exception as e:
         print(f"이미지 다운로드 실패 ({url[:30]}...): {e}")
         return None
 
-# httpx와 asyncio.gather를 이용한 초고속 병렬 다운로드
+
 async def download_images(image_urls: list, save_dir: str = "insta_vibes") -> list:
     if not image_urls:
         return []
 
-    # exist_ok=True를 주면 이미 폴더가 있어도 에러가 나지 않습니다.
     os.makedirs(save_dir, exist_ok=True)
 
-    # 모든 이미지를 동시에 병렬 다운로드
     async with httpx.AsyncClient(headers=FAKE_HEADERS, http2=True) as client:
         tasks = [_download_single_image(client, url, save_dir) for url in image_urls]
         results = await asyncio.gather(*tasks)
 
-    # 실패한(None) 다운로드를 걸러내고 성공한 경로만 반환
     return [path for path in results if path is not None]


### PR DESCRIPTION
### Motivation
- Reduce brittleness from class-hash selectors by switching caption extraction to semantic DOM hierarchy and aria/role-friendly selectors to remain robust against frequent class renames. 
- Avoid noisy/duplicate image results caused by mixed thumbnails and responsive assets by selecting the highest-resolution candidate from `srcset`. 
- Lower bot-detection signals and interaction determinism by adding stealth/fingerprint mitigations and higher-entropy human-like timings and mouse sequences. 
- Prevent memory and format issues when saving media by streaming downloads and using content-type based extension detection. 

### Description
- Replaced fragile classname heuristics with a DOM-hierarchy caption extractor that targets `article ul li` and `span[dir='auto']` and removed the previous `len > 15` heuristic. 
- Added `_extract_highest_resolution_srcset` to parse `srcset` entries and pick the largest resolution, and used it when collecting image URLs to reduce duplicates and low-res picks. 
- Integrated `playwright_stealth` and a small `navigator.webdriver` mask, added `page.on("response")` interception to capture GraphQL/API JSON payloads into `graphql_payloads`, and introduced gaussian `human_delay` plus mouse move/down/up sequences for carousel navigation. 
- Introduced `InstagramAccountPool` for simple session/cookie rotation and temporary-block cooldown tracking, and replaced full-buffer image writes with `httpx` streaming plus `_extension_from_content_type` for proper file extensions. 

### Testing
- Ran Python syntax check with `python -m py_compile project/backend/Step1/instagram_crawler.py`, which completed successfully. 
- No additional automated unit tests were added or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0009e2cb78832aa031fca83f715f9a)